### PR TITLE
Add prototyped implementation for StateChanged event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ build
 composer.lock
 vendor
 coverage
-.idea
-.phpunit.*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build
 composer.lock
 vendor
 coverage
+.idea
+.phpunit.*

--- a/src/Events/StateChanged.php
+++ b/src/Events/StateChanged.php
@@ -11,43 +11,27 @@ class StateChanged
 {
     use SerializesModels;
 
-    /**
-     * @var State
-     */
+    /** @var \Spatie\State\State */
     public $initialState;
 
-    /**
-     * @var State
-     */
+    /** @var \Spatie\State\State */
     public $finalState;
 
-    /**
-     * @var Transition
-     */
+    /** @var \Spatie\State\Transition */
     public $transition;
 
-    /**
-     * @var Model
-     */
-    public $subject;
+    /** @var \Illuminate\Database\Eloquent\Model */
+    public $model;
 
-    /**
-     * StateChanged constructor.
-     *
-     * @param State      $initialState
-     * @param State      $finalState
-     * @param Transition $transition
-     * @param Model      $subject
-     */
     public function __construct(
         State $initialState,
         State $finalState,
         Transition $transition,
-        Model $subject
+        Model $model
     ) {
         $this->initialState = $initialState;
         $this->finalState = $finalState;
         $this->transition = $transition;
-        $this->subject = $subject;
+        $this->model = $model;
     }
 }

--- a/src/Events/StateChanged.php
+++ b/src/Events/StateChanged.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Spatie\State\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+use Spatie\State\State;
+use Spatie\State\Transition;
+
+class StateChanged
+{
+    use SerializesModels;
+
+    /**
+     * @var State
+     */
+    public $initialState;
+
+    /**
+     * @var State
+     */
+    public $finalState;
+
+    /**
+     * @var Transition
+     */
+    public $transition;
+
+    /**
+     * @var Model
+     */
+    public $subject;
+
+    /**
+     * StateChanged constructor.
+     *
+     * @param State      $initialState
+     * @param State      $finalState
+     * @param Transition $transition
+     * @param Model      $subject
+     */
+    public function __construct(
+        State $initialState,
+        State $finalState,
+        Transition $transition,
+        Model $subject
+    ) {
+        $this->initialState = $initialState;
+        $this->finalState = $finalState;
+        $this->transition = $transition;
+        $this->subject = $subject;
+    }
+}

--- a/src/State.php
+++ b/src/State.php
@@ -225,11 +225,9 @@ abstract class State
             };
         }
 
-        $initialState = $this;
-
         $mutatedModel = app()->call([$transition, 'handle']);
 
-        event(new StateChanged($initialState, $mutatedModel->state, $transition, $this->model));
+        event(new StateChanged($this, $mutatedModel->state, $transition, $this->model));
 
         return $mutatedModel;
     }

--- a/src/State.php
+++ b/src/State.php
@@ -5,6 +5,7 @@ namespace Spatie\State;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use ReflectionClass;
+use Spatie\State\Events\StateChanged;
 use Spatie\State\Exceptions\CouldNotPerformTransition;
 use Spatie\State\Exceptions\InvalidConfig;
 
@@ -224,7 +225,13 @@ abstract class State
             };
         }
 
-        return app()->call([$transition, 'handle']);
+        $initialState = $this;
+
+        $mutatedModel = app()->call([$transition, 'handle']);
+
+        event(new StateChanged($initialState, $mutatedModel->state, $transition, $this->model));
+
+        return $mutatedModel;
     }
 
     /**

--- a/tests/StateChangedEventTest.php
+++ b/tests/StateChangedEventTest.php
@@ -28,9 +28,9 @@ class StateChangedEventTest extends TestCase
         Event::assertDispatched(
         StateChanged::class,
             function (StateChanged $event) use ($original, $payment) {
-                $this->assertTrue($original === $event->initialState);
-                $this->assertTrue($payment->state === $event->finalState);
-                $this->assertTrue($payment === $event->model);
+                $this->assertEquals($original, $event->initialState);
+                $this->assertEquals($payment->state, $event->finalState);
+                $this->assertEquals($payment, $event->model);
                 $this->assertInstanceOf(PendingToPaid::class, $event->transition);
 
                 return true;

--- a/tests/StateChangedEventTest.php
+++ b/tests/StateChangedEventTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Spatie\State\Tests;
+
+use Illuminate\Support\Facades\Event;
+use Spatie\State\Events\StateChanged;
+use Spatie\State\Exceptions\CouldNotPerformTransition;
+use Spatie\State\Tests\Dummy\Payment;
+use Spatie\State\Tests\Dummy\States\Paid;
+use Spatie\State\Tests\Dummy\States\Pending;
+use Spatie\State\Tests\Dummy\Transitions\PendingToPaid;
+
+class StateChangedEventTest extends TestCase
+{
+    /** @test */
+    public function state_changed_event_is_fired_after_transition_run()
+    {
+        Event::fake();
+
+        $payment = new Payment();
+
+        $payment->state = new Pending($payment);
+
+        $original = $payment->state;
+
+        try {
+            $payment->state->transition(PendingToPaid::class);
+        } catch (CouldNotPerformTransition $e) {
+        }
+
+        Event::assertDispatched(StateChanged::class);
+
+        /** StateChanged $e */
+        Event::assertDispatched(StateChanged::class, function ($e) use ($original, $payment) {
+            return ($e->finalState == $payment->state) == ($e->initialState == $original);
+        });
+    }
+}


### PR DESCRIPTION
Whenever the `transition` method is called and after a successful event mutation has occurred, the `StateChanged` event is dispatched so that users can hook into it.

The event provides the original model state, the state after performing the mutation and the related transition and model.

- [x] Test to ensure the event is dispatched and the data passed to the user is in place.