### PR TITLE
Added tests for int names

### DIFF
--- a/tests/Dummy/AutoDetectStates/StateIntOne.php
+++ b/tests/Dummy/AutoDetectStates/StateIntOne.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AutoDetectStates;
+
+class StateIntOne extends AbstractState
+{
+    public static $name = 1;
+}

--- a/tests/Dummy/States/PaidWithCode.php
+++ b/tests/Dummy/States/PaidWithCode.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\States;
+
+class PaidWithCode extends PaymentState
+{
+    public static $name = 1;
+
+    public function color(): string
+    {
+        return 'green';
+    }
+}

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\ModelStates\Tests;
 
+use Spatie\ModelStates\Tests\Dummy\AutoDetectStates\StateIntOne;
 use Spatie\ModelStates\Tests\Dummy\Payment;
+use Spatie\ModelStates\Tests\Dummy\States\PaidWithCode;
 use Spatie\ModelStates\Tests\Dummy\WrongState;
 use Spatie\ModelStates\Tests\Dummy\States\Paid;
 use Spatie\ModelStates\Exceptions\InvalidConfig;
@@ -16,6 +18,7 @@ use Spatie\ModelStates\Tests\Dummy\AutoDetectStates\AbstractState;
 
 class StateTest extends TestCase
 {
+    /** @test */
     public function state_with_name_is_saved_with_its_class_name()
     {
         $payment = Payment::create([
@@ -28,6 +31,21 @@ class StateTest extends TestCase
         ]);
 
         $this->assertInstanceOf(PaidWithoutName::class, $payment->state);
+    }
+
+    /** @test */
+    public function state_with_int_code_is_saved_with_int_name_property()
+    {
+        $payment = Payment::create([
+            'state' => PaidWithCode::class,
+        ]);
+
+        $this->assertDatabaseHas('payments', [
+            'id' => $payment->id,
+            'state' => PaidWithCode::getMorphClass(),
+        ]);
+
+        $this->assertInstanceOf(PaidWithCode::class, $payment->state);
     }
 
     /** @test */
@@ -212,6 +230,14 @@ class StateTest extends TestCase
         $state = AbstractState::find('a', new Payment());
 
         $this->assertInstanceOf(StateA::class, $state);
+    }
+
+    /** @test */
+    public function resolve_state_with_int_name()
+    {
+        $state = AbstractState::find(1, new Payment());
+
+        $this->assertInstanceOf(StateIntOne::class, $state);
     }
 
     /** @test */


### PR DESCRIPTION
#12 

Hello! 

migrations currently do not provide good support for enum columns.

instead I am using tinyInt, but the library does not support this kind of column.