### PR TITLE
Remove unused method

### DIFF
--- a/src/Exceptions/InvalidConfig.php
+++ b/src/Exceptions/InvalidConfig.php
@@ -17,13 +17,6 @@ class InvalidConfig extends Exception
         return new self("No state field found for {$modelClass}::{$field}, did you forget to provide a mapping in {$modelClass}::registerStates()?");
     }
 
-    public static function fieldNotFound(string $stateClass, Model $model): InvalidConfig
-    {
-        $modelClass = get_class($model);
-
-        return new self("No state field was found for the state {$stateClass} in {$modelClass}, did you forget to provide a mapping in {$modelClass}::registerStates()?");
-    }
-
     public static function fieldDoesNotExtendState(string $field, string $expectedStateClass, string $actualClass): InvalidConfig
     {
         return new self("State field `{$field}` expects state to be of type `{$expectedStateClass}`, instead got `{$actualClass}`");


### PR DESCRIPTION
`InvalidConfig::fieldNotFound` appears to not be used.