### PR TITLE
Add methods to list states with names as well

### DIFF
--- a/docs/working-with-states/03-listing-states.md
+++ b/docs/working-with-states/03-listing-states.md
@@ -3,7 +3,7 @@ title: Listing states
 weight: 3
 ---
 
-Say you have setup the invoice model as follows:
+Say you have set up the invoice model as follows:
 
 ```php
 namespace App;
@@ -60,13 +60,42 @@ You can get all the registered states with `Invoice::getStates()`, which returns
 ]
 ```
 
-You can also get the registered states for a specific column with `Invoice::getStatesFor('state')`, which returns a colelctions of state classes:
+You can also get the registered states for a specific column with `Invoice::getStatesFor('state')`, which returns a collections of state classes:
 
 ```php
 [
     'App\States\Invoice\Declined',
     'App\States\Invoice\Paid',
     'App\States\Invoice\Pending',
+],
+```
+
+## Get Names of Registered States
+
+If you want the state names instead of the class names, you can call `Invoice::getStateNamesFor('state')` instead. 
+
+```php
+[
+    "state" => [
+        'declined',
+        'paid',
+        'pending',
+    ],
+    "fulfillment" => [
+        'complete',
+        'partial',
+        'unfulfilled',
+    ]
+]
+```
+
+Like the classes, you can also get the registered states for a specific column with `Invoice::getStateNamesFor('state')`:
+
+```php
+[
+    'declined',
+    'paid',
+    'pending',
 ],
 ```
 

--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -196,6 +196,21 @@ trait HasStates
         return static::getStates()->get($column, new Collection);
     }
 
+    public static function getStateNames(): Collection
+    {
+        return collect(static::getStateConfig())
+            ->map(function ($state) {
+                return $state->stateClass::all()->map(function ($stateClass) {
+                    return $stateClass::resolveStateName($stateClass);
+                });
+            });
+    }
+
+    public static function getStateNamesFor(string $column): Collection
+    {
+        return static::getStateNames()->get($column, new Collection);
+    }
+
     public static function getDefaultStates(): Collection
     {
         return collect(static::getStateConfig())

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -319,6 +319,46 @@ JSON;
     }
 
     /** @test */
+    public function names_for_registered_states_can_be_listed()
+    {
+        $expected_states = collect([
+            'paid',
+            'failed',
+            'created',
+            'pending',
+            'canceled',
+            PaidWithoutName::class,
+        ]);
+
+        $states = Payment::getStateNames();
+
+        $this->assertTrue($states->has('state'));
+        $this->assertTrue(
+            $states
+                ->get('state')
+                ->diff($expected_states)
+                ->isEmpty()
+        );
+    }
+
+    /** @test */
+    public function names_for_registered_states_for_specific_column_can_be_listed()
+    {
+        $expected_states = collect([
+            'paid',
+            'failed',
+            'created',
+            'pending',
+            'canceled',
+            PaidWithoutName::class,
+        ]);
+
+        $states = Payment::getStateNamesFor('state');
+
+        $this->assertTrue($expected_states->diff($states)->isEmpty());
+    }
+
+    /** @test */
     public function defaults_states_can_be_listed()
     {
         $states = PaymentWithDefaultStatePaid::getDefaultStates();


### PR DESCRIPTION
Hey,

I was running into the issue where I wanted to list all the available states like the other PR, but I'm using state names and I wanted to list those in an easy way.

I wasn't sure if this was something that should change within the functions introduced by the original PR, which would make `getStatesFor` return the $name instead of the class, but I added a seperate function for it to make sure it doesn't break stuff. I've added tests and docs as well.

Thanks for reading!
