### PR TITLE
Link the field name to the state instance

### DIFF
--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -66,10 +66,14 @@ trait HasStates
                     ? new $stateConfig->defaultStateClass($model)
                     : null;
 
-                /** @var \Spatie\ModelStates\State $state */
-                $state = class_exists($stateClass)
-                    ? new $stateClass($model)
-                    : $defaultState;
+                /** @var null|\Spatie\ModelStates\State $state */
+                $state = $defaultState;
+
+                if(class_exists($stateClass)){
+                    $state = new $stateClass($model);
+
+                    $state->setField($stateConfig->field);
+                }
 
                 $state->setField($stateConfig->field);
 

--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -18,6 +18,15 @@ trait HasStates
 
     abstract protected function registerStates(): void;
 
+    public function __set($name, $value): void
+    {
+        if ($value instanceof State) {
+            $value->setField($name);
+        }
+
+        parent::__set($name, $value);
+    }
+
     public static function bootHasStates(): void
     {
         $serialiseState = function (StateConfig $stateConfig) {
@@ -57,11 +66,16 @@ trait HasStates
                     ? new $stateConfig->defaultStateClass($model)
                     : null;
 
+                /** @var \Spatie\ModelStates\State $state */
+                $state = class_exists($stateClass)
+                    ? new $stateClass($model)
+                    : $defaultState;
+
+                $state->setField($stateConfig->field);
+
                 $model->setAttribute(
                     $stateConfig->field,
-                    class_exists($stateClass)
-                        ? new $stateClass($model)
-                        : $defaultState
+                    $state
                 );
             };
         };

--- a/src/State.php
+++ b/src/State.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\ModelStates;
 
+use Exception;
 use ReflectionClass;
 use JsonSerializable;
 use Illuminate\Support\Collection;
@@ -24,9 +25,28 @@ abstract class State implements JsonSerializable
     /** @var \Illuminate\Database\Eloquent\Model */
     protected $model;
 
+    /** @var string|null */
+    protected $field;
+
     public function __construct(Model $model)
     {
         $this->model = $model;
+    }
+
+    public function setField(string $field): State
+    {
+        $this->field = $field;
+
+        return $this;
+    }
+
+    public function getField(): string
+    {
+        if (! $this->field) {
+            throw new Exception("Could not determine the field name of this state class.");
+        }
+
+        return $this->field;
     }
 
     /**
@@ -301,7 +321,7 @@ abstract class State implements JsonSerializable
         foreach ($files as $file) {
             ['filename' => $className] = pathinfo($file);
 
-            $stateClass = $namespace.'\\'.$className;
+            $stateClass = $namespace . '\\' . $className;
 
             if (! is_subclass_of($stateClass, static::class)) {
                 continue;

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -334,4 +334,24 @@ JSON;
 
         $this->assertEquals($state, Paid::class);
     }
+
+    /** @test */
+    public function the_field_is_correctly_set_on_the_state()
+    {
+        $payment = new Payment();
+        $this->assertEquals('state', $payment->state->getField());
+
+        $payment = Payment::create([
+            'state' => Paid::class,
+        ]);
+        $this->assertEquals('state', $payment->state->getField());
+
+        $payment = new Payment();
+        $payment->state = new Paid($payment);
+        $this->assertEquals('state', $payment->state->getField());
+
+        $payment = new Payment();
+        $payment->state->transitionTo(Pending::class);
+        $this->assertEquals('state', $payment->state->getField());
+    }
 }


### PR DESCRIPTION
I'd like to hear the communities input on this. Right now a state class does not know what model field it belongs to. This makes is that we need to pass in the state field explicitly when calling some methods. Eg:

```php
$model->stateField->transitionableStates('stateField');
```

It's kind of stupid having to pass in this field parameter. In the above case, a shorthand is provided, given that there's only one state field on the model. It's far from an elegant solution, hence this PR.

Note that at the moment, I only added the technical support for coupling state objects to the fields. I still need to refactor the existing `transitionableStates` method. This means this PR would mean a breaking change, though I think it's worth it. I would combine this PR #26 before tagging a v2. 

The downside of this approach is that we're overriding `__set` in the `HasStates` trait, meaning that our implementation might collide with other traits within the same model. Unfortunately Laravel doesn't support any other way at the moment, but I'm writing up a draft proposal to add it.

I'd appreciate any input!