### PR TITLE
Return Eloquent model when using transitionTo method directly

### DIFF
--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -127,6 +127,8 @@ trait HasStates
     /**
      * @param \Spatie\ModelStates\State|string $state
      * @param string|null $field
+     *
+     * @return \Illuminate\Database\Eloquent\Model
      */
     public function transitionTo($state, string $field = null)
     {
@@ -138,7 +140,7 @@ trait HasStates
 
         $field = $field ?? reset($stateConfig)->field;
 
-        $this->{$field}->transitionTo($state);
+        return $this->{$field}->transitionTo($state);
     }
 
     public function transitionableStates(string $fromClass, ?string $field = null): array


### PR DESCRIPTION
When using transitions by calling the `transitionTo` method it returns the Eloquent model:

```
$payment->state->transitionTo(Paid::class);
```

Using the `transitionTo` method directly will return `null`:

```
$payment->transitionTo(Paid::class);
```

This PR fixes this so the Eloquent model will be returned in both cases.