### PR TITLE
Unserialize model state on updated event.

### DIFF
--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -69,7 +69,7 @@ trait HasStates
         foreach (self::getStateConfig() as $stateConfig) {
             static::retrieved($unserialiseState($stateConfig));
             static::created($unserialiseState($stateConfig));
-            static::updated($unserialiseState($stateConfig));
+            static::updated($unserializeState($stateConfig));
             static::saved($unserialiseState($stateConfig));
 
             static::updating($serialiseState($stateConfig));

--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -69,6 +69,7 @@ trait HasStates
         foreach (self::getStateConfig() as $stateConfig) {
             static::retrieved($unserialiseState($stateConfig));
             static::created($unserialiseState($stateConfig));
+            static::updated($unserialiseState($stateConfig));
             static::saved($unserialiseState($stateConfig));
 
             static::updating($serialiseState($stateConfig));

--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -2,11 +2,11 @@
 
 namespace Spatie\ModelStates;
 
-use Illuminate\Support\Collection;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
-use Spatie\ModelStates\Exceptions\InvalidConfig;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use Spatie\ModelStates\Exceptions\CouldNotPerformTransition;
+use Spatie\ModelStates\Exceptions\InvalidConfig;
 
 /**
  * @mixin \Illuminate\Database\Eloquent\Model

--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -67,7 +67,6 @@ trait HasStates
         };
 
         foreach (self::getStateConfig() as $stateConfig) {
-
             static::retrieved($unserializeState($stateConfig));
             static::created($unserializeState($stateConfig));
             static::updated($unserializeState($stateConfig));

--- a/tests/StateUpdatedEventTest.php
+++ b/tests/StateUpdatedEventTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Spatie\ModelStates\Tests;
+
+use Illuminate\Support\Facades\Event;
+use Spatie\ModelStates\Tests\Dummy\Payment;
+use Spatie\ModelStates\Tests\Dummy\States\Paid;
+
+class StateUpdatedEventTest extends TestCase
+{
+    /** @test */
+    public function state_is_properly_unserialized_when_updated_event_is_dispatched()
+    {
+        Event::fake([UpdatedEvent::class]);
+        Payment::observe([PaymentObserver::class]);
+
+        $payment = Payment::create();
+
+        $payment->update([
+            'state' => Paid::class,
+        ]);
+
+        Event::assertDispatched(UpdatedEvent::class, function ($event) {
+            return $event->state->is(Paid::class);
+        });
+    }
+}
+
+class UpdatedEvent
+{
+    public $state;
+
+    public function __construct($state)
+    {
+        $this->state = $state;
+    }
+}
+
+class PaymentObserver
+{
+    public function updated(Payment $payment)
+    {
+        event(new UpdatedEvent($payment->state));
+    }
+}


### PR DESCRIPTION
When you have an observer on your model and the Eloquent `updated` event is called the state is serialized:

```php
class PaymentObserver
{
    public function updated(Payment $payment)
    {
        // $payment->state is a string here   
    }
}
```

This is because the state will be unserialized when the `saved` event is called. This will happen after the `updated` event.

This PR solves this so the state will be unserialized when the `updated` event is fired on the Eloquent model.