### PR TITLE
Call save method only on existent models.

### DIFF
--- a/src/DefaultTransition.php
+++ b/src/DefaultTransition.php
@@ -29,7 +29,9 @@ class DefaultTransition extends Transition
     {
         $this->model->{$this->field} = $this->newState;
 
-        $this->model->save();
+        if ($this->model->exists) {
+            $this->model->save();
+        }
 
         return $this->model;
     }

--- a/tests/Dummy/PaymentWithAllowTransitions.php
+++ b/tests/Dummy/PaymentWithAllowTransitions.php
@@ -8,6 +8,7 @@ use Spatie\ModelStates\Tests\Dummy\States\Paid;
 use Spatie\ModelStates\Tests\Dummy\States\Failed;
 use Spatie\ModelStates\Tests\Dummy\States\Created;
 use Spatie\ModelStates\Tests\Dummy\States\Pending;
+use Spatie\ModelStates\Tests\Dummy\States\Canceled;
 use Spatie\ModelStates\Tests\Dummy\States\PaymentState;
 use Spatie\ModelStates\Tests\Dummy\Transitions\ToFailed;
 use Spatie\ModelStates\Tests\Dummy\Transitions\CreatedToPending;
@@ -49,6 +50,7 @@ class PaymentWithAllowTransitions extends Model
             ->allowTransitions([
                 [Created::class, Pending::class, CreatedToPending::class],
                 [Created::class, Failed::class, ToFailed::class],
+                [Created::class, Canceled::class],
                 [Pending::class, Paid::class],
             ]);
     }

--- a/tests/TransitionToTest.php
+++ b/tests/TransitionToTest.php
@@ -8,6 +8,7 @@ use Spatie\ModelStates\Tests\Dummy\States\Paid;
 use Spatie\ModelStates\Tests\Dummy\States\Failed;
 use Spatie\ModelStates\Tests\Dummy\States\Created;
 use Spatie\ModelStates\Tests\Dummy\States\Pending;
+use Spatie\ModelStates\Tests\Dummy\States\Canceled;
 use Spatie\ModelStates\Tests\Dummy\ModelWithMultipleStates;
 use Spatie\ModelStates\Exceptions\CouldNotPerformTransition;
 use Spatie\ModelStates\Tests\Dummy\PaymentWithAllowTransitions;
@@ -99,5 +100,15 @@ class TransitionToTest extends TestCase
         $model->transitionTo(DummyState::class, 'stateA');
 
         $this->assertInstanceOf(DummyState::class, $model->stateA);
+    }
+
+    /** @test */
+    public function transition_to_on_a_new_model_instance_does_not_get_persisted_to_database()
+    {
+        $payment = new PaymentWithAllowTransitions();
+
+        $payment->state->transitionTo(Canceled::class);
+
+        $this->assertCount(0, Payment::all());
     }
 }


### PR DESCRIPTION
Calling the `transitionTo` method will always save the model.

```
$payment = new Payment();

// or if you are using the firstOrNew method:

$payment = Payment::firstOrNew(['order_reference' => '1234'];

// do some other stuff

$payment->state->transitionTo(SomeState::class);
```

Calling the `transitionTo` method will cause the model to be saved.
I am expecting the state to be changed, however the model should not be saved.

This PR fixes this and I have added a test.
