### PR TITLE
Provides phpdocs for state scopes

### DIFF
--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -10,6 +10,9 @@ use Spatie\ModelStates\Exceptions\InvalidConfig;
 
 /**
  * @mixin \Illuminate\Database\Eloquent\Model
+ *
+ * @method static Builder whereState(string $field, string|string[] $states)
+ * @method static Builder whereNotState(string $field, string|string[] $states)
  */
 trait HasStates
 {


### PR DESCRIPTION
Makes it easier for IDEs to detect that scopes exist for the models using the HasStates trait.