### PR TITLE
Add column name to scope

### DIFF
--- a/docs/querybuilder-support/01-state-scopes.md
+++ b/docs/querybuilder-support/01-state-scopes.md
@@ -12,3 +12,11 @@ $payments = Payment::whereState('state', [Pending::class, Paid::class]);
 $payments = Payment::whereNotState('state', Pending::class);
 $payments = Payment::whereNotState('state', [Failed::class, Canceled::class]);
 ```
+
+When the state field has another column name in the query(for example due to a join), it is possible to provide the column name as a parameter: 
+
+```php
+$payments = Payment::whereState('state', Paid::class, 'payments.state');
+
+$payments = Payment::whereNotState('state', Pending::class, 'payments.state');
+```

--- a/docs/querybuilder-support/01-state-scopes.md
+++ b/docs/querybuilder-support/01-state-scopes.md
@@ -13,10 +13,10 @@ $payments = Payment::whereNotState('state', Pending::class);
 $payments = Payment::whereNotState('state', [Failed::class, Canceled::class]);
 ```
 
-When the state field has another column name in the query(for example due to a join), it is possible to provide the column name as a parameter: 
+When the state field has another column name in the query(for example due to a join), it is possible to use the full column name: 
 
 ```php
-$payments = Payment::whereState('state', Paid::class, 'payments.state');
+$payments = Payment::whereState('payments.state', Paid::class);
 
-$payments = Payment::whereNotState('state', Pending::class, 'payments.state');
+$payments = Payment::whereNotState('payments.state', Pending::class);
 ```

--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -91,9 +91,11 @@ trait HasStates
         }
     }
 
-    public function scopeWhereState(Builder $builder, string $field, $states, ?string $column = null): Builder
+    public function scopeWhereState(Builder $builder, string $column, $states): Builder
     {
-        self::getStateConfig();
+        $columnSegments = explode('.', $column);
+
+        $field = end($columnSegments);
 
         /** @var \Spatie\ModelStates\StateConfig|null $stateConfig */
         $stateConfig = self::getStateConfig()[$field] ?? null;
@@ -108,11 +110,15 @@ trait HasStates
             return $abstractStateClass::resolveStateName($state);
         });
 
-        return $builder->whereIn($column ?? $field, $stateNames);
+        return $builder->whereIn($column ?? $column, $stateNames);
     }
 
-    public function scopeWhereNotState(Builder $builder, string $field, $states, ?string $column = null): Builder
+    public function scopeWhereNotState(Builder $builder, string $column, $states): Builder
     {
+        $columnSegments = explode('.', $column);
+
+        $field = end($columnSegments);
+
         /** @var \Spatie\ModelStates\StateConfig|null $stateConfig */
         $stateConfig = self::getStateConfig()[$field] ?? null;
 
@@ -124,7 +130,7 @@ trait HasStates
             return $stateConfig->stateClass::resolveStateName($state);
         });
 
-        return $builder->whereNotIn($column ?? $field, $stateNames);
+        return $builder->whereNotIn($column ?? $column, $stateNames);
     }
 
     /**

--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -4,6 +4,7 @@ namespace Spatie\ModelStates;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Spatie\ModelStates\Exceptions\CouldNotPerformTransition;
 use Spatie\ModelStates\Exceptions\InvalidConfig;
@@ -93,9 +94,7 @@ trait HasStates
 
     public function scopeWhereState(Builder $builder, string $column, $states): Builder
     {
-        $columnSegments = explode('.', $column);
-
-        $field = end($columnSegments);
+        $field = Arr::last(explode('.', $column));
 
         /** @var \Spatie\ModelStates\StateConfig|null $stateConfig */
         $stateConfig = self::getStateConfig()[$field] ?? null;
@@ -115,9 +114,7 @@ trait HasStates
 
     public function scopeWhereNotState(Builder $builder, string $column, $states): Builder
     {
-        $columnSegments = explode('.', $column);
-
-        $field = end($columnSegments);
+        $field = Arr::last(explode('.', $column));
 
         /** @var \Spatie\ModelStates\StateConfig|null $stateConfig */
         $stateConfig = self::getStateConfig()[$field] ?? null;

--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -91,7 +91,7 @@ trait HasStates
         }
     }
 
-    public function scopeWhereState(Builder $builder, string $field, $states): Builder
+    public function scopeWhereState(Builder $builder, string $field, $states, ?string $column = null): Builder
     {
         self::getStateConfig();
 
@@ -108,10 +108,10 @@ trait HasStates
             return $abstractStateClass::resolveStateName($state);
         });
 
-        return $builder->whereIn($field, $stateNames);
+        return $builder->whereIn($column ?? $field, $stateNames);
     }
 
-    public function scopeWhereNotState(Builder $builder, string $field, $states): Builder
+    public function scopeWhereNotState(Builder $builder, string $field, $states, ?string $column = null): Builder
     {
         /** @var \Spatie\ModelStates\StateConfig|null $stateConfig */
         $stateConfig = self::getStateConfig()[$field] ?? null;
@@ -124,7 +124,7 @@ trait HasStates
             return $stateConfig->stateClass::resolveStateName($state);
         });
 
-        return $builder->whereNotIn($field, $stateNames);
+        return $builder->whereNotIn($column ?? $field, $stateNames);
     }
 
     /**

--- a/tests/Dummy/Payment.php
+++ b/tests/Dummy/Payment.php
@@ -24,8 +24,8 @@ use Spatie\ModelStates\Tests\Dummy\Transitions\ToFailed;
  *
  * @property \Spatie\ModelStates\Tests\Dummy\States\PaymentState state
  *
- * @method static self whereState(string $field, $state)
- * @method static self whereNotState(string $field, $state)
+ * @method static self whereState(string $field, $state, string|null $column = null)
+ * @method static self whereNotState(string $field, $state, string|null $column = null)
  * @method int count
  */
 class Payment extends Model

--- a/tests/Dummy/Payment.php
+++ b/tests/Dummy/Payment.php
@@ -24,8 +24,8 @@ use Spatie\ModelStates\Tests\Dummy\Transitions\ToFailed;
  *
  * @property \Spatie\ModelStates\Tests\Dummy\States\PaymentState state
  *
- * @method static self whereState(string $field, $state, string|null $column = null)
- * @method static self whereNotState(string $field, $state, string|null $column = null)
+ * @method static self whereState(string $field, $state)
+ * @method static self whereNotState(string $field, $state)
  * @method int count
  */
 class Payment extends Model

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -54,12 +54,12 @@ class ScopeTest extends TestCase
 
         $paidPayment = Payment::create(['state' => Paid::class]);
 
-        $this->assertEquals(1, Payment::whereState('state', Paid::class, 'payments.state')->count());
-        $this->assertEquals(1, Payment::whereState('state', Created::class, 'payments.state')->count());
-        $this->assertEquals(2, Payment::whereState('state', [Created::class, Paid::class], 'payments.state')->count());
+        $this->assertEquals(1, Payment::whereState('payments.state', Paid::class)->count());
+        $this->assertEquals(1, Payment::whereState('payments.state', Created::class)->count());
+        $this->assertEquals(2, Payment::whereState('payments.state', [Created::class, Paid::class])->count());
 
-        $this->assertTrue($paidPayment->is(Payment::whereState('state', Paid::class, 'payments.state')->first()));
-        $this->assertTrue($createdPayment->is(Payment::whereState('state', Created::class, 'payments.state')->first()));
+        $this->assertTrue($paidPayment->is(Payment::whereState('payments.state', Paid::class)->first()));
+        $this->assertTrue($createdPayment->is(Payment::whereState('payments.state', Created::class)->first()));
     }
 
     /** @test */
@@ -69,11 +69,11 @@ class ScopeTest extends TestCase
 
         $paidPayment = Payment::create(['state' => Paid::class]);
 
-        $this->assertEquals(1, Payment::whereNotState('state', Paid::class, 'payments.state')->count());
-        $this->assertEquals(1, Payment::whereNotState('state', Created::class, 'payments.state')->count());
-        $this->assertEquals(0, Payment::whereNotState('state', [Created::class, Paid::class], 'payments.state')->count());
+        $this->assertEquals(1, Payment::whereNotState('payments.state', Paid::class)->count());
+        $this->assertEquals(1, Payment::whereNotState('payments.state', Created::class)->count());
+        $this->assertEquals(0, Payment::whereNotState('payments.state', [Created::class, Paid::class])->count());
 
-        $this->assertFalse($paidPayment->is(Payment::whereNotState('state', Paid::class, 'payments.state')->first()));
-        $this->assertFalse($createdPayment->is(Payment::whereNotState('state', Created::class, 'payments.state')->first()));
+        $this->assertFalse($paidPayment->is(Payment::whereNotState('payments.state', Paid::class)->first()));
+        $this->assertFalse($createdPayment->is(Payment::whereNotState('payments.state', Created::class)->first()));
     }
 }

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -46,4 +46,34 @@ class ScopeTest extends TestCase
 
         Payment::whereState('abc', Paid::class);
     }
+
+    /** @test */
+    public function scope_where_state_column_name_differs_from_field_name()
+    {
+        $createdPayment = Payment::create();
+
+        $paidPayment = Payment::create(['state' => Paid::class]);
+
+        $this->assertEquals(1, Payment::whereState('state', Paid::class, 'payments.state')->count());
+        $this->assertEquals(1, Payment::whereState('state', Created::class, 'payments.state')->count());
+        $this->assertEquals(2, Payment::whereState('state', [Created::class, Paid::class], 'payments.state')->count());
+
+        $this->assertTrue($paidPayment->is(Payment::whereState('state', Paid::class, 'payments.state')->first()));
+        $this->assertTrue($createdPayment->is(Payment::whereState('state', Created::class, 'payments.state')->first()));
+    }
+
+    /** @test */
+    public function scope_where_not_state_column_name_differs_from_field_name()
+    {
+        $createdPayment = Payment::create();
+
+        $paidPayment = Payment::create(['state' => Paid::class]);
+
+        $this->assertEquals(1, Payment::whereNotState('state', Paid::class, 'payments.state')->count());
+        $this->assertEquals(1, Payment::whereNotState('state', Created::class, 'payments.state')->count());
+        $this->assertEquals(0, Payment::whereNotState('state', [Created::class, Paid::class], 'payments.state')->count());
+
+        $this->assertFalse($paidPayment->is(Payment::whereNotState('state', Paid::class, 'payments.state')->first()));
+        $this->assertFalse($createdPayment->is(Payment::whereNotState('state', Created::class, 'payments.state')->first()));
+    }
 }


### PR DESCRIPTION
We're having some difficulties in a client's project 😉, let's say we have a `payments` table that is joined by a `orders` table. Both tables have a status field so to select the `payments` status field we need to use `payments.status`. When trying to scope this:

```php
Payments::whereState('payments.status', Paid::class);
```

We get an error, because the `payments.status` state does not exists, only the `status` state exists.

This PR add a third parameter to the scope where a column can be specified:

```php
Payments::whereState('status', Paid::class, 'payments.status');
```

Extra note:
Another solution could be to only use the last part of the state to look up the state, so for `payments.status` this would be `status`. But I'm not sure this is covering all the cases.