### PR TITLE
Docblock fixes.

### DIFF
--- a/tests/Dummy/ModelWithIntState.php
+++ b/tests/Dummy/ModelWithIntState.php
@@ -9,7 +9,7 @@ use Spatie\ModelStates\Tests\Dummy\IntStates\IntState;
 use Spatie\ModelStates\Tests\Dummy\IntStates\IntStateA;
 
 /**
- * @property \Spatie\ModelStates\Tests\Dummy\IntStates\IntState state
+ * @property \Spatie\ModelStates\Tests\Dummy\IntStates\IntState $state
  */
 class ModelWithIntState extends Model
 {

--- a/tests/Dummy/Payment.php
+++ b/tests/Dummy/Payment.php
@@ -13,20 +13,20 @@ use Spatie\ModelStates\Tests\Dummy\Transitions\CreatedToPending;
 use Spatie\ModelStates\Tests\Dummy\Transitions\ToFailed;
 
 /**
- * @method static \Spatie\ModelStates\Tests\Dummy\Payment first
+ * @method static \Spatie\ModelStates\Tests\Dummy\Payment first()
  * @method static \Spatie\ModelStates\Tests\Dummy\Payment find(int $id)
  * @method static \Spatie\ModelStates\Tests\Dummy\Payment create(array $data = [])
- * @property int id
- * @property \Carbon\Carbon failed_at
- * @property \Carbon\Carbon paid_at
- * @property \Carbon\Carbon pending_at
- * @property string error_message
+ * @property int $id
+ * @property string $cancelled_at
+ * @property string $failed_at
+ * @property string $paid_at
+ * @property string $error_message
  *
- * @property \Spatie\ModelStates\Tests\Dummy\States\PaymentState state
+ * @property \Spatie\ModelStates\Tests\Dummy\States\PaymentState $state
  *
  * @method static self whereState(string $field, $state)
  * @method static self whereNotState(string $field, $state)
- * @method int count
+ * @method int count()
  */
 class Payment extends Model
 {

--- a/tests/Dummy/PaymentWithAllowTransitions.php
+++ b/tests/Dummy/PaymentWithAllowTransitions.php
@@ -13,20 +13,20 @@ use Spatie\ModelStates\Tests\Dummy\Transitions\CreatedToPending;
 use Spatie\ModelStates\Tests\Dummy\Transitions\ToFailed;
 
 /**
- * @method static self first
+ * @method static self first()
  * @method static self find(int $id)
  * @method static self create(array $data = [])
- * @property int id
- * @property \Carbon\Carbon failed_at
- * @property \Carbon\Carbon paid_at
- * @property \Carbon\Carbon pending_at
- * @property string error_message
+ * @property int $id
+ * @property string $cancelled_at
+ * @property string $failed_at
+ * @property string $paid_at
+ * @property string $error_message
  *
- * @property \Spatie\ModelStates\Tests\Dummy\States\PaymentState state
+ * @property \Spatie\ModelStates\Tests\Dummy\States\PaymentState $state
  *
  * @method static self whereState(string $field, $state)
  * @method static self whereNotState(string $field, $state)
- * @method int count
+ * @method int count()
  */
 class PaymentWithAllowTransitions extends Model
 {

--- a/tests/Dummy/PaymentWithDefaultStatePaid.php
+++ b/tests/Dummy/PaymentWithDefaultStatePaid.php
@@ -8,20 +8,20 @@ use Spatie\ModelStates\Tests\Dummy\States\Paid;
 use Spatie\ModelStates\Tests\Dummy\States\PaymentState;
 
 /**
- * @method static self first
+ * @method static self first()
  * @method static self find(int $id)
  * @method static self create(array $data = [])
- * @property int id
- * @property \Carbon\Carbon failed_at
- * @property \Carbon\Carbon paid_at
- * @property \Carbon\Carbon pending_at
- * @property string error_message
+ * @property int $id
+ * @property string $cancelled_at
+ * @property string $failed_at
+ * @property string $paid_at
+ * @property string $error_message
  *
- * @property \Spatie\ModelStates\Tests\Dummy\States\PaymentState state
+ * @property \Spatie\ModelStates\Tests\Dummy\States\PaymentState $state
  *
  * @method static self whereState(string $field, $state)
  * @method static self whereNotState(string $field, $state)
- * @method int count
+ * @method int count()
  */
 class PaymentWithDefaultStatePaid extends Model
 {

--- a/tests/StateChangedEventTest.php
+++ b/tests/StateChangedEventTest.php
@@ -72,7 +72,7 @@ class StateChangedEventTest extends TestCase
 }
 
 /**
- * @property \Spatie\ModelStates\Tests\AbstractState status
+ * @property \Spatie\ModelStates\Tests\AbstractState $status
  */
 class TestModel extends Model
 {


### PR DESCRIPTION
The `pending_at` column does not exist, a `cancelled_at` column does.

The `cancelled_at`, `failed_at` and `paid_at` attributes are not casted to a `Carbon` instance, so these are just strings.

I noticed that the `cancelled_at` column is not used in any of the tests and may be removed.

