### PR TITLE
Removes double Event::assertDispatched

### DIFF
--- a/tests/StateChangedEventTest.php
+++ b/tests/StateChangedEventTest.php
@@ -27,8 +27,6 @@ class StateChangedEventTest extends TestCase
 
         $payment->state->transition(PendingToPaid::class);
 
-        Event::assertDispatched(StateChanged::class);
-
         Event::assertDispatched(
             StateChanged::class,
             function (StateChanged $event) use ($original, $payment) {


### PR DESCRIPTION
In this test it asserts the `StateChanged` is dispatched twice.
I've removed this double assertion.