### PR TITLE
Obtain fresh payment instance.

### DIFF
--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -69,7 +69,7 @@ class StateTest extends TestCase
             'state' => Paid::getMorphClass(),
         ]);
 
-        $this->assertInstanceOf(Paid::class, $payment->state);
+        $this->assertInstanceOf(Paid::class, $payment->fresh()->state);
     }
 
     /** @test */


### PR DESCRIPTION
This test asserts that the `state` attribute is an instance of the `Paid` class.

By obtaining a fresh instance of the `Payment` model you can be sure that the `state` attribute is properly unserialized when it is retrieved from the database. 