### PR TITLE
Remove unused cancelled_at column.

### DIFF
--- a/tests/Dummy/Payment.php
+++ b/tests/Dummy/Payment.php
@@ -17,7 +17,6 @@ use Spatie\ModelStates\Tests\Dummy\Transitions\ToFailed;
  * @method static \Spatie\ModelStates\Tests\Dummy\Payment find(int $id)
  * @method static \Spatie\ModelStates\Tests\Dummy\Payment create(array $data = [])
  * @property int $id
- * @property string $cancelled_at
  * @property string $failed_at
  * @property string $paid_at
  * @property string $error_message

--- a/tests/Dummy/PaymentWithAllowTransitions.php
+++ b/tests/Dummy/PaymentWithAllowTransitions.php
@@ -17,7 +17,6 @@ use Spatie\ModelStates\Tests\Dummy\Transitions\ToFailed;
  * @method static self find(int $id)
  * @method static self create(array $data = [])
  * @property int $id
- * @property string $cancelled_at
  * @property string $failed_at
  * @property string $paid_at
  * @property string $error_message

--- a/tests/Dummy/PaymentWithDefaultStatePaid.php
+++ b/tests/Dummy/PaymentWithDefaultStatePaid.php
@@ -12,7 +12,6 @@ use Spatie\ModelStates\Tests\Dummy\States\PaymentState;
  * @method static self find(int $id)
  * @method static self create(array $data = [])
  * @property int $id
- * @property string $cancelled_at
  * @property string $failed_at
  * @property string $paid_at
  * @property string $error_message

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -30,7 +30,6 @@ abstract class TestCase extends Orchestra
             $table->increments('id');
             $table->string('state')->nullable();
             $table->datetime('paid_at')->nullable();
-            $table->datetime('cancelled_at')->nullable();
             $table->datetime('failed_at')->nullable();
             $table->string('error_message')->nullable();
             $table->timestamps();


### PR DESCRIPTION
The `cancelled_at` column is not used in any of the tests, so I removed it.