### PR TITLE
Replace larapack/dd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     },
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^2.6",
-        "larapack/dd": "^1.0",
         "orchestra/testbench": "^3.8|^4.0",
-        "phpunit/phpunit": "^8.2"
+        "phpunit/phpunit": "^8.2",
+        "symfony/var-dumper": "^4.4|^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`larapack/dd` just provides helper methods, they already exist in the `symfony/var-dumper` package.

Removed `larapack/dd` in favor of `symfony/var-dumper`.