### PR TITLE
Remove laravel-ide-helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "laravel/framework": "~5.8|^6.0"
     },
     "require-dev": {
-        "barryvdh/laravel-ide-helper": "^2.6",
         "larapack/dd": "^1.0",
         "orchestra/testbench": "^3.8|^4.0",
         "phpunit/phpunit": "^8.2"


### PR DESCRIPTION
I don't think there is a need to include the `barryvdh/laravel-ide-helper` package as a dev requirement, so I have removed it.