### PR TITLE
Change static to self

### DIFF
--- a/src/State.php
+++ b/src/State.php
@@ -110,7 +110,7 @@ abstract class State implements JsonSerializable
             return get_class($state);
         }
 
-        foreach (static::resolveStateMapping() as $stateClass) {
+        foreach (self::resolveStateMapping() as $stateClass) {
             if (! class_exists($stateClass)) {
                 continue;
             }


### PR DESCRIPTION
The `resolveStateMapping` method is declared private, so calling it with `self` instead of `static`.