### PR TITLE
Resolve state from name without explicit states.

### DIFF
--- a/tests/Dummy/PaymentWithAutoDetectState.php
+++ b/tests/Dummy/PaymentWithAutoDetectState.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy;
+
+use Spatie\ModelStates\HasStates;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\ModelStates\Tests\Dummy\AutoDetectStates\StateA;
+use Spatie\ModelStates\Tests\Dummy\AutoDetectStates\StateB;
+use Spatie\ModelStates\Tests\Dummy\AutoDetectStates\AbstractState;
+
+/**
+ * @method static self first()
+ * @method static self find(int $id)
+ * @method static self create(array $data = [])
+ * @property int $id
+ * @property string $failed_at
+ * @property string $paid_at
+ * @property string $error_message
+ *
+ * @property \Spatie\ModelStates\Tests\Dummy\States\PaymentState $state
+ *
+ * @method static self whereState(string $field, $state)
+ * @method static self whereNotState(string $field, $state)
+ * @method int count()
+ */
+class PaymentWithAutoDetectState extends Model
+{
+    use HasStates;
+
+    protected $table = 'payments';
+
+    protected $guarded = [];
+
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+    }
+
+    protected function registerStates(): void
+    {
+        $this->addState('state', AbstractState::class);
+            // ->allowTransition(StateA::class, StateB::class)
+            // ->allowTransition(StateB::class, StateA::class);
+    }
+}

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -2,21 +2,23 @@
 
 namespace Spatie\ModelStates\Tests;
 
-use Spatie\ModelStates\Exceptions\InvalidConfig;
-use Spatie\ModelStates\Tests\Dummy\AutoDetectStates\AbstractState;
-use Spatie\ModelStates\Tests\Dummy\AutoDetectStates\StateA;
-use Spatie\ModelStates\Tests\Dummy\IntStates\IntStateA;
-use Spatie\ModelStates\Tests\Dummy\ModelWithIntState;
 use Spatie\ModelStates\Tests\Dummy\Payment;
-use Spatie\ModelStates\Tests\Dummy\PaymentWithDefaultStatePaid;
-use Spatie\ModelStates\Tests\Dummy\States\Canceled;
-use Spatie\ModelStates\Tests\Dummy\States\Created;
-use Spatie\ModelStates\Tests\Dummy\States\Failed;
-use Spatie\ModelStates\Tests\Dummy\States\Paid;
-use Spatie\ModelStates\Tests\Dummy\States\PaidWithoutName;
-use Spatie\ModelStates\Tests\Dummy\States\PaymentState;
-use Spatie\ModelStates\Tests\Dummy\States\Pending;
 use Spatie\ModelStates\Tests\Dummy\WrongState;
+use Spatie\ModelStates\Tests\Dummy\States\Paid;
+use Spatie\ModelStates\Exceptions\InvalidConfig;
+use Spatie\ModelStates\Tests\Dummy\States\Failed;
+use Spatie\ModelStates\Tests\Dummy\States\Created;
+use Spatie\ModelStates\Tests\Dummy\States\Pending;
+use Spatie\ModelStates\Tests\Dummy\States\Canceled;
+use Spatie\ModelStates\Tests\Dummy\ModelWithIntState;
+use Spatie\ModelStates\Tests\Dummy\IntStates\IntStateA;
+use Spatie\ModelStates\Tests\Dummy\States\PaymentState;
+use Spatie\ModelStates\Tests\Dummy\States\PaidWithoutName;
+use Spatie\ModelStates\Tests\Dummy\AutoDetectStates\StateA;
+use Spatie\ModelStates\Tests\Dummy\AutoDetectStates\StateB;
+use Spatie\ModelStates\Tests\Dummy\PaymentWithAutoDetectState;
+use Spatie\ModelStates\Tests\Dummy\PaymentWithDefaultStatePaid;
+use Spatie\ModelStates\Tests\Dummy\AutoDetectStates\AbstractState;
 
 class StateTest extends TestCase
 {
@@ -334,5 +336,41 @@ JSON;
         $state = PaymentWithDefaultStatePaid::getDefaultStateFor('state');
 
         $this->assertEquals($state, Paid::class);
+    }
+
+    /** @test */
+    public function equals_without_explicit_mapping()
+    {
+        $stateA = new StateA(new PaymentWithAutoDetectState);
+        $stateB = new StateB(new PaymentWithAutoDetectState);
+
+        $this->assertTrue($stateA->equals(StateA::class));
+        $this->assertTrue($stateB->equals(StateB::class));
+        $this->assertTrue($stateA->equals('a'));
+        $this->assertFalse($stateA->equals($stateB));
+    }
+
+    /** @test */
+    public function is_one_of_without_explicit_mapping()
+    {
+        $stateA = new StateA(new PaymentWithAutoDetectState);
+        $stateB = new StateB(new PaymentWithAutoDetectState);
+
+        $this->assertTrue($stateA->isOneOf(
+            StateA::class,
+            StateB::class
+        ));
+
+        $this->assertTrue($stateA->isOneOf(
+            new StateA(new PaymentWithAutoDetectState)
+        ));
+
+        $this->assertTrue($stateA->isOneOf(
+            'a'
+        ));
+
+        $this->assertFalse($stateA->isOneOf(
+            StateB::class
+        ));
     }
 }


### PR DESCRIPTION
- `isOneOf` and `equals` do not work unless states are explicitly listed.
- closes #85 