### PR TITLE
Fix scope with state zero

### DIFF
--- a/src/State.php
+++ b/src/State.php
@@ -117,7 +117,9 @@ abstract class State implements JsonSerializable
 
             // Loose comparison is needed here in order to support non-string values,
             // Laravel casts their database value automatically to strings if we didn't specify the fields in `$casts`.
-            if (($stateClass::$name ?? null) == $state) {
+            $name = isset($stateClass::$name) ? (string) $stateClass::$name : null;
+
+            if ($name == $state) {
                 return $stateClass;
             }
         }

--- a/tests/Dummy/IntStates/IntStateB.php
+++ b/tests/Dummy/IntStates/IntStateB.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\IntStates;
+
+class IntStateB extends IntState
+{
+    public static $name = 0;
+}

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -3,6 +3,9 @@
 namespace Spatie\ModelStates\Tests;
 
 use Spatie\ModelStates\Exceptions\InvalidConfig;
+use Spatie\ModelStates\Tests\Dummy\IntStates\IntStateA;
+use Spatie\ModelStates\Tests\Dummy\IntStates\IntStateB;
+use Spatie\ModelStates\Tests\Dummy\ModelWithIntState;
 use Spatie\ModelStates\Tests\Dummy\Payment;
 use Spatie\ModelStates\Tests\Dummy\States\Created;
 use Spatie\ModelStates\Tests\Dummy\States\Paid;
@@ -75,5 +78,25 @@ class ScopeTest extends TestCase
 
         $this->assertFalse($paidPayment->is(Payment::whereNotState('payments.state', Paid::class)->first()));
         $this->assertFalse($createdPayment->is(Payment::whereNotState('payments.state', Created::class)->first()));
+    }
+
+    /** @test */
+    public function scope_with_states_saved_as_tiny_ints()
+    {
+        ModelWithIntState::migrate();
+
+        $modelA = ModelWithIntState::create([
+            'state' => IntStateA::class,
+        ]);
+
+        $modelB = ModelWithIntState::create([
+            'state' => IntStateB::class,
+        ]);
+
+        $this->assertTrue(ModelWithIntState::whereState('state', IntStateA::class)->first()->is($modelA));
+        $this->assertTrue(ModelWithIntState::whereNotState('state', IntStateA::class)->first()->is($modelB));
+
+        $this->assertTrue(ModelWithIntState::whereState('state', IntStateB::class)->first()->is($modelB));
+        $this->assertTrue(ModelWithIntState::whereNotState('state', IntStateB::class)->first()->is($modelA));
     }
 }


### PR DESCRIPTION
I had two states, let's say `Draft` and `Published` with values of `0` and `1`:

```php
class Draft extends PostState
{
    public static $name = 0;
}

// and

class Published extends PostState
{
    public static $name = 1;
}
```

Now when you scope the model like so:

```php
Post::whereState('state', Draft::class)
```

This will return the published ones instead of the expected posts with state `Draft`.
This is because of the `$name` property in the `Draft` state is set to `0`.

In this scenario the state class is not resolved properly in the `resolveStateClass` method.

This PR aims to solve this issue.
Added a test as well.

 