### PR TITLE
Add HasStates transition check method

### DIFF
--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -168,6 +168,39 @@ trait HasStates
     }
 
     /**
+     * @param \Spatie\ModelStates\State[]|string[] $states
+     * @param string|null $field
+     *
+     * @return bool
+     */
+    public function canTransitionTo(array $states, ?string $field = null): bool
+    {
+        $statesConfig = self::getStateConfig();
+
+        if ($field === null && count($statesConfig) > 1) {
+            throw InvalidConfig::unknownState($field, $this);
+        }
+
+        $field = $field ?? reset($statesConfig)->field;
+
+        $stateConfig = $statesConfig[$field];
+
+        foreach ($states as $to) {
+
+            try {
+                $this->resolveTransitionClass(
+                    $stateConfig->stateClass::resolveStateClass($this->$field),
+                    $stateConfig->stateClass::resolveStateClass($to)
+                );
+            } catch (CouldNotPerformTransition $exception){
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * @param string $fromClass
      * @param string $toClass
      *

--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -168,12 +168,12 @@ trait HasStates
     }
 
     /**
-     * @param \Spatie\ModelStates\State[]|string[] $states
+     * @param \Spatie\ModelStates\State|string $to
      * @param string|null $field
      *
      * @return bool
      */
-    public function canTransitionTo(array $states, ?string $field = null): bool
+    public function canTransitionTo($to, ?string $field = null): bool
     {
         $statesConfig = self::getStateConfig();
 
@@ -185,16 +185,13 @@ trait HasStates
 
         $stateConfig = $statesConfig[$field];
 
-        foreach ($states as $to) {
-
-            try {
-                $this->resolveTransitionClass(
-                    $stateConfig->stateClass::resolveStateClass($this->$field),
-                    $stateConfig->stateClass::resolveStateClass($to)
-                );
-            } catch (CouldNotPerformTransition $exception){
-                return false;
-            }
+        try {
+            $this->resolveTransitionClass(
+                $stateConfig->stateClass::resolveStateClass($this->$field),
+                $stateConfig->stateClass::resolveStateClass($to)
+            );
+        } catch (CouldNotPerformTransition $exception){
+            return false;
         }
 
         return true;

--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -178,7 +178,7 @@ trait HasStates
         $statesConfig = self::getStateConfig();
 
         if ($field === null && count($statesConfig) > 1) {
-            throw InvalidConfig::unknownState($field, $this);
+            throw InvalidConfig::fieldNotFound(($to instanceof State) ? get_class($to) : $to, $this);
         }
 
         $field = $field ?? reset($statesConfig)->field;
@@ -190,7 +190,7 @@ trait HasStates
                 $stateConfig->stateClass::resolveStateClass($this->$field),
                 $stateConfig->stateClass::resolveStateClass($to)
             );
-        } catch (CouldNotPerformTransition $exception){
+        } catch (CouldNotPerformTransition $exception) {
             return false;
         }
 

--- a/tests/Dummy/PaymentWithMultipleStates.php
+++ b/tests/Dummy/PaymentWithMultipleStates.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\ModelStates\HasStates;
+use Spatie\ModelStates\Tests\Dummy\States\Created;
+use Spatie\ModelStates\Tests\Dummy\States\Failed;
+use Spatie\ModelStates\Tests\Dummy\States\Paid;
+use Spatie\ModelStates\Tests\Dummy\States\PaymentState;
+use Spatie\ModelStates\Tests\Dummy\States\Pending;
+use Spatie\ModelStates\Tests\Dummy\Transitions\CreatedToPending;
+use Spatie\ModelStates\Tests\Dummy\Transitions\ToFailed;
+
+/**
+ * @method static \Spatie\ModelStates\Tests\Dummy\Payment first()
+ * @method static \Spatie\ModelStates\Tests\Dummy\Payment find(int $id)
+ * @method static \Spatie\ModelStates\Tests\Dummy\Payment create(array $data = [])
+ * @property int $id
+ * @property string $failed_at
+ * @property string $paid_at
+ * @property string $error_message
+ *
+ * @property \Spatie\ModelStates\Tests\Dummy\States\PaymentState $state
+ *
+ * @method static self whereState(string $field, $state)
+ * @method static self whereNotState(string $field, $state)
+ * @method int count()
+ */
+class PaymentWithMultipleStates extends Model
+{
+    use HasStates;
+
+    protected $table = 'payments_with_multiple_states';
+
+    protected $guarded = [];
+
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->stateA = $this->stateA ?? new Created($this);
+        $this->stateB = $this->stateB ?? new Created($this);
+    }
+
+    protected function registerStates(): void
+    {
+        $this->addState('stateA', PaymentState::class)
+            ->allowTransition(Created::class, Pending::class, CreatedToPending::class)
+            ->allowTransition([Created::class, Pending::class], Failed::class, ToFailed::class)
+            ->allowTransition(Pending::class, Paid::class);
+
+        $this->addState('stateB', PaymentState::class)
+            ->allowTransition(Created::class, Pending::class, CreatedToPending::class)
+            ->allowTransition([Created::class, Pending::class], Failed::class, ToFailed::class)
+            ->allowTransition(Pending::class, Paid::class);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -35,6 +35,16 @@ abstract class TestCase extends Orchestra
             $table->timestamps();
         });
 
+        $this->app->get('db')->connection()->getSchemaBuilder()->create('payments_with_multiple_states', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('stateA')->nullable();
+            $table->string('stateB')->nullable();
+            $table->datetime('paid_at')->nullable();
+            $table->datetime('failed_at')->nullable();
+            $table->string('error_message')->nullable();
+            $table->timestamps();
+        });
+
         $this->app->get('db')->connection()->getSchemaBuilder()->create('model_with_multiple_states', function (Blueprint $table) {
             $table->increments('id');
             $table->string('stateA')->nullable();

--- a/tests/TransitionToTest.php
+++ b/tests/TransitionToTest.php
@@ -108,8 +108,8 @@ class TransitionToTest extends TestCase
             'state' => Created::class,
         ]);
 
-        $this->assertTrue($payment->canTransitionTo([Pending::class]));
-        $this->assertFalse($payment->canTransitionTo([Paid::class]));
+        $this->assertTrue($payment->canTransitionTo(Pending::class));
+        $this->assertFalse($payment->canTransitionTo(Paid::class));
     }
 
     /** @test */
@@ -119,7 +119,7 @@ class TransitionToTest extends TestCase
             'state' => Created::class,
         ]);
 
-        $this->assertTrue($payment->canTransitionTo(['pending']));
-        $this->assertFalse($payment->canTransitionTo(['paid']));
+        $this->assertTrue($payment->canTransitionTo('pending'));
+        $this->assertFalse($payment->canTransitionTo('paid'));
     }
 }

--- a/tests/TransitionToTest.php
+++ b/tests/TransitionToTest.php
@@ -100,4 +100,26 @@ class TransitionToTest extends TestCase
 
         $this->assertInstanceOf(DummyState::class, $model->stateA);
     }
+
+    /** @test */
+    public function state_can_transition_to_class()
+    {
+        $payment = Payment::create([
+            'state' => Created::class,
+        ]);
+
+        $this->assertTrue($payment->canTransitionTo([Pending::class]));
+        $this->assertFalse($payment->canTransitionTo([Paid::class]));
+    }
+
+    /** @test */
+    public function state_can_transition_to_name()
+    {
+        $payment = Payment::create([
+            'state' => Created::class,
+        ]);
+
+        $this->assertTrue($payment->canTransitionTo(['pending']));
+        $this->assertFalse($payment->canTransitionTo(['paid']));
+    }
 }

--- a/tests/TransitionToTest.php
+++ b/tests/TransitionToTest.php
@@ -3,10 +3,12 @@
 namespace Spatie\ModelStates\Tests;
 
 use Spatie\ModelStates\Exceptions\CouldNotPerformTransition;
+use Spatie\ModelStates\Exceptions\InvalidConfig;
 use Spatie\ModelStates\Tests\Dummy\DummyState;
 use Spatie\ModelStates\Tests\Dummy\ModelWithMultipleStates;
 use Spatie\ModelStates\Tests\Dummy\Payment;
 use Spatie\ModelStates\Tests\Dummy\PaymentWithAllowTransitions;
+use Spatie\ModelStates\Tests\Dummy\PaymentWithMultipleStates;
 use Spatie\ModelStates\Tests\Dummy\States\Created;
 use Spatie\ModelStates\Tests\Dummy\States\Failed;
 use Spatie\ModelStates\Tests\Dummy\States\Paid;
@@ -121,5 +123,79 @@ class TransitionToTest extends TestCase
 
         $this->assertTrue($payment->canTransitionTo('pending'));
         $this->assertFalse($payment->canTransitionTo('paid'));
+    }
+
+    /** @test */
+    public function state_can_transition_to_state_instance()
+    {
+        $payment = Payment::create([
+            'state' => Created::class,
+        ]);
+
+        $this->assertTrue($payment->canTransitionTo(new Pending($payment)));
+        $this->assertFalse($payment->canTransitionTo(new Paid($payment)));
+    }
+
+    /** @test */
+    public function transition_to_with_multiple_states_throws_exception_on_undefined_class_field()
+    {
+        $this->expectException(InvalidConfig::class);
+
+        $payment = PaymentWithMultipleStates::create();
+
+        $payment->canTransitionTo(Pending::class);
+    }
+
+    /** @test */
+    public function transition_to_with_multiple_states_throws_exception_on_undefined_name_field()
+    {
+        $this->expectException(InvalidConfig::class);
+
+        $payment = PaymentWithMultipleStates::create();
+
+        $payment->canTransitionTo('pending');
+    }
+
+    /** @test */
+    public function transition_to_with_multiple_states_throws_exception_on_undefined_instance_field()
+    {
+        $this->expectException(InvalidConfig::class);
+
+        $payment = PaymentWithMultipleStates::create();
+
+        $payment->canTransitionTo(new Pending($payment));
+    }
+
+    /** @test */
+    public function explicitly_defined_state_can_transition_to_class()
+    {
+        $payment = PaymentWithMultipleStates::create([
+            'stateA' => Created::class,
+        ]);
+
+        $this->assertTrue($payment->canTransitionTo(Pending::class, 'stateA'));
+        $this->assertFalse($payment->canTransitionTo(Paid::class, 'stateA'));
+    }
+
+    /** @test */
+    public function explicitly_defined_state_can_transition_to_name()
+    {
+        $payment = PaymentWithMultipleStates::create([
+            'stateA' => Created::class,
+        ]);
+
+        $this->assertTrue($payment->canTransitionTo('pending', 'stateA'));
+        $this->assertFalse($payment->canTransitionTo('paid', 'stateA'));
+    }
+
+    /** @test */
+    public function explicitly_defined_state_can_transition_to_state_instance()
+    {
+        $payment = PaymentWithMultipleStates::create([
+            'stateA' => Created::class,
+        ]);
+
+        $this->assertTrue($payment->canTransitionTo(new Pending($payment), 'stateA'));
+        $this->assertFalse($payment->canTransitionTo(new Paid($payment), 'stateA'));
     }
 }


### PR DESCRIPTION
I ran into a scenario where I wanted to check if a **currently applied state** can transition to another given state. Instead of trying the transition using `transition()` or `transitionTo()` and catching any exception I added a new `canTransitionTo($to, ?string $field = null)` method.

#### Example usage

```php
use Spatie\ModelStates\Tests\Dummy\Payment;
use Spatie\ModelStates\Tests\Dummy\States\Created;
use Spatie\ModelStates\Tests\Dummy\States\Paid;
use Spatie\ModelStates\Tests\Dummy\States\Pending;

$payment = Payment::create([
    'state' => Created::class,
]);

$payment->canTransitionTo(Pending::class); // true
$payment->canTransitionTo('pending');      // true

$payment->canTransitionTo(Paid::class);    // false
$payment->canTransitionTo('paid');         // false
```