### PR TITLE
Set getter attribute in TransitionNotFound

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 vendor
 coverage
 .phpunit.result.cache
+/.idea

--- a/src/Exceptions/TransitionNotFound.php
+++ b/src/Exceptions/TransitionNotFound.php
@@ -32,7 +32,7 @@ class TransitionNotFound extends CouldNotPerformTransition implements ProvidesSo
         return $this;
     }
 
-    public function getFrom(string $from): string
+    public function getFrom(): string
     {
         return $this->from;
     }
@@ -44,7 +44,7 @@ class TransitionNotFound extends CouldNotPerformTransition implements ProvidesSo
         return $this;
     }
 
-    public function getTo(string $to): string
+    public function getTo(): string
     {
        return $this->to;
     }
@@ -56,7 +56,7 @@ class TransitionNotFound extends CouldNotPerformTransition implements ProvidesSo
         return $this;
     }
 
-    public function getModelClass(string $modelClass): string
+    public function getModelClass(): string
     {
         return $this->modelClass;
     }

--- a/src/Exceptions/TransitionNotFound.php
+++ b/src/Exceptions/TransitionNotFound.php
@@ -9,13 +9,13 @@ use Facade\IgnitionContracts\Solution;
 class TransitionNotFound extends CouldNotPerformTransition implements ProvidesSolution
 {
     /** @var string */
-    public $from;
+    protected $from;
 
     /** @var string */
-    public $to;
+    protected $to;
 
     /** @var string */
-    public $modelClass;
+    protected $modelClass;
 
     public static function make(string $from, string $to, string $modelClass): self
     {

--- a/src/Exceptions/TransitionNotFound.php
+++ b/src/Exceptions/TransitionNotFound.php
@@ -9,13 +9,13 @@ use Facade\IgnitionContracts\Solution;
 class TransitionNotFound extends CouldNotPerformTransition implements ProvidesSolution
 {
     /** @var string */
-    protected $from;
+    public $from;
 
     /** @var string */
-    protected $to;
+    public $to;
 
     /** @var string */
-    protected $modelClass;
+    public $modelClass;
 
     public static function make(string $from, string $to, string $modelClass): self
     {

--- a/src/Exceptions/TransitionNotFound.php
+++ b/src/Exceptions/TransitionNotFound.php
@@ -32,6 +32,11 @@ class TransitionNotFound extends CouldNotPerformTransition implements ProvidesSo
         return $this;
     }
 
+    public function getFrom(string $from): string
+    {
+        return $this->from;
+    }
+
     public function setTo(string $to): self
     {
         $this->to = $to;
@@ -39,11 +44,21 @@ class TransitionNotFound extends CouldNotPerformTransition implements ProvidesSo
         return $this;
     }
 
+    public function getTo(string $to): string
+    {
+       return $this->to;
+    }
+
     public function setModelClass(string $modelClass): self
     {
         $this->modelClass = $modelClass;
 
         return $this;
+    }
+
+    public function getModelClass(string $modelClass): string
+    {
+        return $this->modelClass;
     }
 
     public function getSolution(): Solution


### PR DESCRIPTION
To make easily get current update when reach exception handler

 ```php
    // App\Exceptions\Handler
    public function render($request, Throwable $exception)
    {
        if ($request->expectsJson() && $exception instanceof TransitionNotFound) {

            $from = $exception->getFrom();
            $to = $exception->getTo();
            $model = $exception->getModelClass();

            $from = (new $from(new $model()))::$name;
            $to = (new $to(new $model()))::$name;

            $exception = new HttpException(
                Response::HTTP_UNPROCESSABLE_ENTITY,
                "Invalid transition from $from to $to.",
                $exception
            );
        }

        return parent::render($request, $exception);
    }
```

will result:
```
{
    "message": "Invalid transition from in-queue to in-queue.",
```

state class:
```php
<?php

namespace App\States\Orders;

class OrderInQueueState extends BaseOrderState
{
    public static $name = 'in-queue';

}
```