### PR TITLE
Support Laravel 8

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,9 +11,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [7.4, 7.3, 7.2]
-        laravel: [5.8.*, 6.*, 7.*]
+        laravel: [5.8.*, 6.*, 7.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
+        exclude:
+          -   laravel: 8.*
+          -   php: 7.2
         include:
+          -   laravel: 8.*
+              testbench: 6.*
           -   laravel: 7.*
               testbench: 5.*
           -   laravel: 6.*

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
         "php": "^7.2",
         "ext-json": "*",
         "facade/ignition-contracts": "^1.0",
-        "laravel/framework": "~5.8|^6.0|^7.0"
+        "laravel/framework": "~5.8|^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.8|^4.0|^5.0",
+        "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^8.2|^9.0",
         "symfony/var-dumper": "^4.4|^5.0"
     },


### PR DESCRIPTION
Minimum PHP version for Laravel 8 will be 7.3, so we don't need to test against PHP 7.2.
Added an `exclude` to the matrix in `run-tests.yml` but I am not sure if I did this correctly.