### PR TITLE
Modify originalIsEquivalent check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.2",
         "ext-json": "*",
         "facade/ignition-contracts": "^1.0",
-        "laravel/framework": "~5.8|^6.0|^7.0|^8.0"
+        "laravel/framework": "^7.0|^8.0"
     },
     "require-dev": {
         "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0",

--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -264,4 +264,26 @@ trait HasStates
     {
         return static::getDefaultStates()->get($column);
     }
+
+    /**
+     * Determine if the new and old values for a given key are equivalent.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function originalIsEquivalent($key)
+    {
+        $original = Arr::get($this->original, $key);
+
+        if ($original instanceof State) {
+            $attribute = $original::resolveStateName(Arr::get($this->attributes, $key));
+            $original = $original::resolveStateName($original);
+
+            if ($original === $attribute) {
+                return true;
+            }
+        }
+
+        return parent::originalIsEquivalent($key);
+    }
 }

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -3,9 +3,11 @@
 namespace Spatie\ModelStates\Tests;
 
 use Spatie\ModelStates\Exceptions\InvalidConfig;
+use Spatie\ModelStates\State;
 use Spatie\ModelStates\Tests\Dummy\AutoDetectStates\AbstractState;
 use Spatie\ModelStates\Tests\Dummy\AutoDetectStates\StateA;
 use Spatie\ModelStates\Tests\Dummy\IntStates\IntStateA;
+use Spatie\ModelStates\Tests\Dummy\IntStates\IntStateB;
 use Spatie\ModelStates\Tests\Dummy\ModelWithIntState;
 use Spatie\ModelStates\Tests\Dummy\Payment;
 use Spatie\ModelStates\Tests\Dummy\PaymentWithDefaultStatePaid;
@@ -334,5 +336,101 @@ JSON;
         $state = PaymentWithDefaultStatePaid::getDefaultStateFor('state');
 
         $this->assertEquals($state, Paid::class);
+    }
+
+    /** @test */
+    public function original_is_equivalent_after_creation()
+    {
+        ModelWithIntState::migrate();
+
+        $model = ModelWithIntState::create([
+            'state' => IntStateA::class,
+        ]);
+
+        $this->assertFalse($model->isDirty('state'));
+    }
+
+    /** @test */
+    public function original_is_equivalent_after_update_class()
+    {
+        ModelWithIntState::migrate();
+
+        $model = ModelWithIntState::create([
+            'state' => IntStateA::class,
+        ]);
+
+        $model->state = IntStateA::class;
+
+        $this->assertFalse($model->isDirty('state'));
+    }
+
+    /** @test */
+    public function original_is_equivalent_after_update_string()
+    {
+        ModelWithIntState::migrate();
+
+        $model = ModelWithIntState::create([
+            'state' => IntStateA::class,
+        ]);
+
+        $model->state = IntStateA::resolveStateName(IntStateA::class);
+
+        $this->assertFalse($model->isDirty('state'));
+    }
+
+    /** @test */
+    public function original_is_equivalent_after_update_object()
+    {
+        ModelWithIntState::migrate();
+
+        $model = ModelWithIntState::create([
+            'state' => IntStateA::class,
+        ]);
+
+        $model->state = new IntStateA($model);
+
+        $this->assertFalse($model->isDirty('state'));
+    }
+
+    /** @test */
+    public function original_is_not_equivalent_after_update_class()
+    {
+        ModelWithIntState::migrate();
+
+        $model = ModelWithIntState::create([
+            'state' => IntStateA::class,
+        ]);
+
+        $model->state = IntStateB::class;
+
+        $this->assertTrue($model->isDirty('state'));
+    }
+
+    /** @test */
+    public function original_is_not_equivalent_after_update_string()
+    {
+        ModelWithIntState::migrate();
+
+        $model = ModelWithIntState::create([
+            'state' => IntStateA::class,
+        ]);
+
+        $model->state = IntStateB::resolveStateName(IntStateB::class);
+
+        $this->assertTrue($model->isDirty('state'));
+    }
+
+    /** @test */
+    public function original_is_not_equivalent_after_update_object()
+    {
+        ModelWithIntState::migrate();
+
+        $model = ModelWithIntState::create([
+            'state' => IntStateA::class,
+        ]);
+
+        $model->state = new IntStateB($model);
+
+        $this->assertTrue($model->isDirty('state'));
     }
 }


### PR DESCRIPTION
We noticed when checking `isDirty` on a model that hasn't yet been saved, in an observer or somewhere else, we would get true even if the state hasn't really changed.  I've added an override of `originalIsEquivalent` to fix this.