### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ composer.lock
 vendor
 coverage
 .phpunit.result.cache
-/.idea


### PR DESCRIPTION
With PR #99 a commit was merged which added `.idea` to `.gitignore`. This is not needed here. 

Reverts https://github.com/spatie/laravel-model-states/pull/99/commits/21ab899d1778a70da80ed67ca6156819fc540f35