### PR TITLE
Custom transitions same arguments

### DIFF
--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -139,15 +139,14 @@ trait HasStates
      */
     public function transitionTo($state, string $field = null)
     {
-        $stateConfigs = self::getStateConfig();
+        $stateConfig = self::getStateConfig();
 
-        if ($field === null && count($stateConfigs) > 1) {
+        if ($field === null && count($stateConfig) > 1) {
             throw CouldNotPerformTransition::couldNotResolveTransitionField($this);
         }
 
-        $field = $field ?? reset($stateConfigs)->field;
-        $stateConfig = $stateConfigs[$field];
-        $stateClass = $stateConfig->stateClass::resolveStateClass($state);
+        $field = $field ?? reset($stateConfig)->field;
+        $stateClass = $stateConfig[$field]->stateClass::resolveStateClass($state);
 
         return $this->{$field}->transitionTo($state, $field, new $stateClass($this));
     }

--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -139,15 +139,17 @@ trait HasStates
      */
     public function transitionTo($state, string $field = null)
     {
-        $stateConfig = self::getStateConfig();
+        $stateConfigs = self::getStateConfig();
 
-        if ($field === null && count($stateConfig) > 1) {
+        if ($field === null && count($stateConfigs) > 1) {
             throw CouldNotPerformTransition::couldNotResolveTransitionField($this);
         }
 
-        $field = $field ?? reset($stateConfig)->field;
+        $field = $field ?? reset($stateConfigs)->field;
+        $stateConfig = $stateConfigs[$field];
+        $stateClass = $stateConfig->stateClass::resolveStateClass($state);
 
-        return $this->{$field}->transitionTo($state);
+        return $this->{$field}->transitionTo($state, $field, new $stateClass($this));
     }
 
     public function transitionableStates(string $fromClass, ?string $field = null): array


### PR DESCRIPTION
I do not know if this should be included, but I faced an issue when my custom transitions does not receive same arguments as DefaultTransition and I really needed those. So I came up with this solution. Please check this carefully, I will make fixed if needed or add more code to {$field}->transitionTo() as if used directly it wont have those arguments attached.