### PR TITLE
Fix bug on two consecutive transitions

### DIFF
--- a/src/State.php
+++ b/src/State.php
@@ -152,6 +152,7 @@ abstract class State implements Castable, JsonSerializable
         }
 
         $model = app()->call([$transition, 'handle']);
+        $model->{$this->field}->setField($this->field);
 
         event(new StateChanged(
             $this,

--- a/tests/TransitionTest.php
+++ b/tests/TransitionTest.php
@@ -163,4 +163,19 @@ class TransitionTest extends TestCase
                 && $event->model->is($model);
         });
     }
+
+    /** @test */
+    public function can_transition_twice()
+    {
+        $model = TestModel::create([
+            'state' => StateA::class,
+        ]);
+
+        $model->state->transitionTo(StateB::class);
+        $model->state->transitionTo(StateC::class);
+
+        $model->refresh();
+
+        $this->assertInstanceOf(StateC::class, $model->state);
+    }
 }


### PR DESCRIPTION
laravel-model-states give the following error when one attempts to make two consecutive transitions:
~~~
Error: Typed property Spatie\ModelStates\State::$field must not be accessed before initialization
~~~

The problem is that when a new state is created by transition(), the $field property is not set. Therefore, the first transition is ok (because $field is set when the model is retrieved), but the second fails.

The pull request contains a possible solution and a test for the issue.