### PR TITLE
Update 02-custom-transition-classes.md

### DIFF
--- a/docs/working-with-transitions/02-custom-transition-classes.md
+++ b/docs/working-with-transitions/02-custom-transition-classes.md
@@ -77,9 +77,8 @@ class CreatedToFailed extends Transition
 
     public function canTransition(): bool
     {
-        return $this->payment->state->is(Created::class);
+        return $this->payment->state->equals(Created::class);
     
-        // return $this->payment->state->isOneOf(Created::class, Pending::class);
     }
 }
 ```


### PR DESCRIPTION
change is() to equals() because doesn't exists in v2.