### PR TITLE
ADD default transition config value

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ You can install the package via composer:
 composer require spatie/laravel-model-states
 ```
 
+You can publish the config file with:
+```bash
+php artisan vendor:publish --provider="Spatie\ModelStates\ModelStatesServiceProvider" --tag="laravel-model-states-config"
+```
+
+This is the content of the published config file:
+
+```php
+return [
+
+    /*
+     * The fully qualified class name of the default transition.
+     */
+    'default_transition' => Spatie\ModelStates\DefaultTransition::class,
+
+];
+```
+
 ## Usage
 
 Please refer to the [docs](https://docs.spatie.be/laravel-model-states/v2/01-introduction/) to learn how to use this package.

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "facade/ignition-contracts": "^1.0",
         "illuminate/contracts": "^8.0",
         "illuminate/database": "^8.0",
-        "illuminate/support": "^8.0"
+        "illuminate/support": "^8.0",
+        "spatie/laravel-package-tools": "^1.1"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",
@@ -44,6 +45,13 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Spatie\\ModelStates\\ModelStatesServiceProvider"
+            ]
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/config/model-states.php
+++ b/config/model-states.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+
+    /*
+     * The fully qualified class name of the default transition.
+     */
+    'default_transition' => Spatie\ModelStates\DefaultTransition::class,
+
+];

--- a/docs/04-installation-setup.md
+++ b/docs/04-installation-setup.md
@@ -8,3 +8,24 @@ laravel-model-states can install the package via composer:
 ```bash
 composer require spatie/laravel-model-states
 ```
+
+## Publishing the config file
+
+Publishing the config file is optional:
+
+```bash
+php artisan vendor:publish --provider="Spatie\ModelStates\ModelStatesServiceProvider" --tag="laravel-model-states-config"
+```
+
+This is the default content of the config file:
+
+```php
+return [
+
+    /*
+     * The fully qualified class name of the default transition.
+     */
+    'default_transition' => Spatie\ModelStates\DefaultTransition::class,
+
+];
+```

--- a/src/ModelStatesServiceProvider.php
+++ b/src/ModelStatesServiceProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\ModelStates;
+
+use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
+
+class ModelStatesServiceProvider extends PackageServiceProvider
+{
+    public function configurePackage(Package $package): void
+    {
+        $package
+            ->name('laravel-model-states')
+            ->hasConfigFile();
+    }
+}

--- a/src/State.php
+++ b/src/State.php
@@ -239,7 +239,9 @@ abstract class State implements Castable, JsonSerializable
         $transitionClass = $this->stateConfig->resolveTransitionClass($from, $to);
 
         if ($transitionClass === null) {
-            $transition = new DefaultTransition(
+            $defaultTransition = config('model-states.default_transition', DefaultTransition::class);
+
+            $transition = new $defaultTransition(
                 $this->model,
                 $this->field,
                 $newState

--- a/tests/Dummy/TestModel.php
+++ b/tests/Dummy/TestModel.php
@@ -26,6 +26,10 @@ class TestModel extends Model
         'state' => ModelState::class,
     ];
 
+    protected $dispatchesEvents = [
+        'updating' => TestModelUpdatingEvent::class,
+    ];
+
     public function getTable()
     {
         return 'test_models';

--- a/tests/Dummy/TestModelUpdatingEvent.php
+++ b/tests/Dummy/TestModelUpdatingEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy;
+
+class TestModelUpdatingEvent
+{
+    public TestModel $model;
+
+    public function __construct(TestModel $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/tests/Dummy/Transitions/CustomDefaultTransition.php
+++ b/tests/Dummy/Transitions/CustomDefaultTransition.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\Transitions;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\ModelStates\DefaultTransition;
+
+class CustomDefaultTransition extends DefaultTransition
+{
+    public function handle(): Model
+    {
+        $originalState = $this->model->{$this->field} ? clone $this->model->{$this->field} : null;
+
+        $this->model->{$this->field} = $this->newState;
+
+        $this->model->saveQuietly();
+
+        return $this->model;
+    }
+}

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -2,12 +2,14 @@
 
 namespace Spatie\ModelStates\Tests;
 
+use Illuminate\Support\Facades\Event;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\ModelState;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateA;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateB;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateC;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateD;
 use Spatie\ModelStates\Tests\Dummy\TestModel;
+use Spatie\ModelStates\Tests\Dummy\TestModelUpdatingEvent;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithDefault;
 
 class StateTest extends TestCase
@@ -188,5 +190,20 @@ class StateTest extends TestCase
         $model = TestModel::create();
 
         $this->assertEquals('state', $model->state->getField());
+    }
+
+    /** @test */
+    public function can_override_default_transition()
+    {
+        Event::fake();
+
+        config()->set(
+            'model-states.default_transition',
+            \Spatie\ModelStates\Tests\Dummy\Transitions\CustomDefaultTransition::class
+        );
+
+        TestModel::create()->state->transitionTo(StateB::class);
+
+        Event::assertNotDispatched(TestModelUpdatingEvent::class);
     }
 }


### PR DESCRIPTION
This pull request adds a config file (using your `spatie/laravel-package-tools` package) with a `default_transition` variable used to define (thus eventually override) the default transition class being used by the package.

This could be helpful in many cases: for example, my project has a model subscriber who listens to the `updating` event, but I don't want it to be fired when updating the model state. This can be solved by saving **quietly** the model changes: here's the reason why I'd need to customize the DefaultTransition class!

I updated the README and also the docs file, hope I didn't miss anything!