### PR TITLE
allow extends of DefaultTransition use as transition

### DIFF
--- a/src/State.php
+++ b/src/State.php
@@ -245,6 +245,7 @@ abstract class State implements Castable, JsonSerializable
                 $newState
             );
         } else {
+            $transitionArgs = [...$transitionArgs, $this->getField(), $newState];
             $transition = new $transitionClass($this->model, ...$transitionArgs);
         }
 


### PR DESCRIPTION
this changes is safe for user who use custom transition, but allow use extension of DefaultTransition as transition.
Also it allow to aware about newState from custom transition.
It's useful when config looks like:
    public static function config(): StateConfig
    {
        return parent::config()
            ->allowTransition(Pending::class, Paid::class)
            ->allowTransition(Pending::class, Failed::class, CommonTransition::class);
            ->allowTransition(Pending::class, Wait::class, CommonTransition::class);
    }
and do some useful in CommonTransition::handle 
class CommonTransition extends DefaultTransition
{
    public function handle(): Model
    {
        $model = parent::handle();
        CustomLog::createLog($model->id, Auth::user(), $this->newState);
        return $model;
    }
}
Of course  it's possible to implement it by event, but looks like event is overhead.