### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ composer require spatie/laravel-model-states
 
 You can publish the config file with:
 ```bash
-php artisan vendor:publish --provider="Spatie\ModelStates\ModelStatesServiceProvider" --tag="laravel-model-states-config"
+php artisan vendor:publish --provider="Spatie\ModelStates\ModelStatesServiceProvider" --tag="model-states-config"
 ```
 
 This is the content of the published config file:


### PR DESCRIPTION
```
$ php artisan vendor:publish --provider="Spatie\ModelStates\ModelStatesServiceProvider" --tag="laravel-model-states-config"
Unable to locate publishable resources.
Publishing complete.
$ php artisan vendor:publish --provider="Spatie\ModelStates\ModelStatesServiceProvider" --tag="model-states-config"
Copied File [/vendor/spatie/laravel-model-states/config/model-states.php] To [/config/model-states.php]
Publishing complete.
```