### PR TITLE
When checking if a transition is allowed, also check the custom Transition

### DIFF
--- a/src/State.php
+++ b/src/State.php
@@ -34,7 +34,7 @@ abstract class State implements Castable, JsonSerializable
 
         $baseClass = $reflection->name;
 
-        while ($reflection && ! $reflection->isAbstract()) {
+        while ($reflection && !$reflection->isAbstract()) {
             $reflection = $reflection->getParentClass();
 
             $baseClass = $reflection->name;
@@ -61,7 +61,7 @@ abstract class State implements Castable, JsonSerializable
 
     public static function getStateMapping(): Collection
     {
-        if (! isset(self::$stateMapping[static::class])) {
+        if (!isset(self::$stateMapping[static::class])) {
             self::$stateMapping[static::class] = static::resolveStateMapping();
         }
 
@@ -79,13 +79,13 @@ abstract class State implements Castable, JsonSerializable
         }
 
         foreach (static::getStateMapping() as $stateClass) {
-            if (! class_exists($stateClass)) {
+            if (!class_exists($stateClass)) {
                 continue;
             }
 
             // Loose comparison is needed here in order to support non-string values,
             // Laravel casts their database value automatically to strings if we didn't specify the fields in `$casts`.
-            $name = isset($stateClass::$name) ? (string) $stateClass::$name : null;
+            $name = isset($stateClass::$name) ? (string)$stateClass::$name : null;
 
             if ($name == $state) {
                 return $stateClass;
@@ -99,7 +99,7 @@ abstract class State implements Castable, JsonSerializable
     {
         $stateClass = static::resolveStateClass($name);
 
-        if (! is_subclass_of($stateClass, static::class)) {
+        if (!is_subclass_of($stateClass, static::class)) {
             throw InvalidConfig::doesNotExtendBaseClass($name, static::class);
         }
 
@@ -139,7 +139,7 @@ abstract class State implements Castable, JsonSerializable
 
         $to = $newState::getMorphClass();
 
-        if (! $this->stateConfig->isTransitionAllowed($from, $to)) {
+        if (!$this->stateConfig->isTransitionAllowed($from, $to)) {
             throw CouldNotPerformTransition::notFound($from, $to, $this->model);
         }
 
@@ -156,7 +156,7 @@ abstract class State implements Castable, JsonSerializable
     public function transition(Transition $transition): Model
     {
         if (method_exists($transition, 'canTransition')) {
-            if (! $transition->canTransition()) {
+            if (!$transition->canTransition()) {
                 throw CouldNotPerformTransition::notAllowed($this->model, $transition);
             }
         }
@@ -179,7 +179,7 @@ abstract class State implements Castable, JsonSerializable
         return $this->stateConfig->transitionableStates(static::getMorphClass());
     }
 
-    public function canTransitionTo($newState): bool
+    public function canTransitionTo($newState, ...$transitionArgs): bool
     {
         $newState = $this->resolveStateObject($newState);
 
@@ -187,7 +187,21 @@ abstract class State implements Castable, JsonSerializable
 
         $to = $newState::getMorphClass();
 
-        return $this->stateConfig->isTransitionAllowed($from, $to);
+        if (!$this->stateConfig->isTransitionAllowed($from, $to)) {
+            return false;
+        }
+
+        $transition = $this->resolveTransitionClass(
+            $from,
+            $to,
+            $newState,
+            ...$transitionArgs
+        );
+
+        if (method_exists($transition, 'canTransition')) {
+            return $transition->canTransition();
+        }
+        return true;
     }
 
     public function getValue(): string
@@ -233,9 +247,10 @@ abstract class State implements Castable, JsonSerializable
     private function resolveTransitionClass(
         string $from,
         string $to,
-        State $newState,
-        ...$transitionArgs
-    ): Transition {
+        State  $newState,
+               ...$transitionArgs
+    ): Transition
+    {
         $transitionClass = $this->stateConfig->resolveTransitionClass($from, $to);
 
         if ($transitionClass === null) {
@@ -275,7 +290,7 @@ abstract class State implements Castable, JsonSerializable
             /** @var \Spatie\ModelStates\State|mixed $stateClass */
             $stateClass = $namespace . '\\' . $className;
 
-            if (! is_subclass_of($stateClass, $stateConfig->baseStateClass)) {
+            if (!is_subclass_of($stateClass, $stateConfig->baseStateClass)) {
                 continue;
             }
 

--- a/src/State.php
+++ b/src/State.php
@@ -34,7 +34,7 @@ abstract class State implements Castable, JsonSerializable
 
         $baseClass = $reflection->name;
 
-        while ($reflection && !$reflection->isAbstract()) {
+        while ($reflection && ! $reflection->isAbstract()) {
             $reflection = $reflection->getParentClass();
 
             $baseClass = $reflection->name;
@@ -61,7 +61,7 @@ abstract class State implements Castable, JsonSerializable
 
     public static function getStateMapping(): Collection
     {
-        if (!isset(self::$stateMapping[static::class])) {
+        if (! isset(self::$stateMapping[static::class])) {
             self::$stateMapping[static::class] = static::resolveStateMapping();
         }
 
@@ -79,13 +79,13 @@ abstract class State implements Castable, JsonSerializable
         }
 
         foreach (static::getStateMapping() as $stateClass) {
-            if (!class_exists($stateClass)) {
+            if (! class_exists($stateClass)) {
                 continue;
             }
 
             // Loose comparison is needed here in order to support non-string values,
             // Laravel casts their database value automatically to strings if we didn't specify the fields in `$casts`.
-            $name = isset($stateClass::$name) ? (string)$stateClass::$name : null;
+            $name = isset($stateClass::$name) ? (string) $stateClass::$name : null;
 
             if ($name == $state) {
                 return $stateClass;
@@ -99,7 +99,7 @@ abstract class State implements Castable, JsonSerializable
     {
         $stateClass = static::resolveStateClass($name);
 
-        if (!is_subclass_of($stateClass, static::class)) {
+        if (! is_subclass_of($stateClass, static::class)) {
             throw InvalidConfig::doesNotExtendBaseClass($name, static::class);
         }
 
@@ -139,7 +139,7 @@ abstract class State implements Castable, JsonSerializable
 
         $to = $newState::getMorphClass();
 
-        if (!$this->stateConfig->isTransitionAllowed($from, $to)) {
+        if (! $this->stateConfig->isTransitionAllowed($from, $to)) {
             throw CouldNotPerformTransition::notFound($from, $to, $this->model);
         }
 
@@ -156,7 +156,7 @@ abstract class State implements Castable, JsonSerializable
     public function transition(Transition $transition): Model
     {
         if (method_exists($transition, 'canTransition')) {
-            if (!$transition->canTransition()) {
+            if (! $transition->canTransition()) {
                 throw CouldNotPerformTransition::notAllowed($this->model, $transition);
             }
         }
@@ -187,7 +187,7 @@ abstract class State implements Castable, JsonSerializable
 
         $to = $newState::getMorphClass();
 
-        if (!$this->stateConfig->isTransitionAllowed($from, $to)) {
+        if (! $this->stateConfig->isTransitionAllowed($from, $to)) {
             return false;
         }
 
@@ -247,10 +247,9 @@ abstract class State implements Castable, JsonSerializable
     private function resolveTransitionClass(
         string $from,
         string $to,
-        State  $newState,
-               ...$transitionArgs
-    ): Transition
-    {
+        State $newState,
+        ...$transitionArgs
+    ): Transition {
         $transitionClass = $this->stateConfig->resolveTransitionClass($from, $to);
 
         if ($transitionClass === null) {
@@ -290,7 +289,7 @@ abstract class State implements Castable, JsonSerializable
             /** @var \Spatie\ModelStates\State|mixed $stateClass */
             $stateClass = $namespace . '\\' . $className;
 
-            if (!is_subclass_of($stateClass, $stateConfig->baseStateClass)) {
+            if (! is_subclass_of($stateClass, $stateConfig->baseStateClass)) {
                 continue;
             }
 

--- a/tests/Dummy/Transitions/CustomTransition.php
+++ b/tests/Dummy/Transitions/CustomTransition.php
@@ -14,11 +14,13 @@ class CustomTransition extends Transition
 
     private string $message;
 
-    public function __construct(TestModelWithCustomTransition $model, string $message)
+    public function __construct(TestModelWithCustomTransition $model, ...$transitionArgs)
     {
         $this->model = $model;
 
-        $this->message = $message;
+        if (array_key_exists(0, $transitionArgs)) {
+            $this->message = $transitionArgs[0];
+        }
     }
 
     public function handle(DummyDependency $dummyDependency): TestModelWithCustomTransition

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -11,6 +11,7 @@ use Spatie\ModelStates\Tests\Dummy\ModelStates\StateD;
 use Spatie\ModelStates\Tests\Dummy\TestModel;
 use Spatie\ModelStates\Tests\Dummy\TestModelUpdatingEvent;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithDefault;
+use Spatie\ModelStates\Tests\Dummy\Transitions\CustomTransition;
 
 class StateTest extends TestCase
 {
@@ -68,11 +69,13 @@ class StateTest extends TestCase
     public function test_can_transition_to()
     {
         $state = new StateA(new TestModel());
+        $state->setField('state');
 
         $this->assertTrue($state->canTransitionTo(StateB::class));
         $this->assertTrue($state->canTransitionTo(StateC::class));
 
         $state = new StateB(new TestModel());
+        $state->setField('state');
 
         $this->assertFalse($state->canTransitionTo(StateB::class));
         $this->assertFalse($state->canTransitionTo(StateA::class));

--- a/tests/TransitionTest.php
+++ b/tests/TransitionTest.php
@@ -13,6 +13,7 @@ use Spatie\ModelStates\Tests\Dummy\ModelStates\StateC;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateD;
 use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateX;
 use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateY;
+use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateZ;
 use Spatie\ModelStates\Tests\Dummy\TestModel;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithCustomTransition;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithTransitionsFromArray;
@@ -143,6 +144,26 @@ class TransitionTest extends TestCase
         $this->expectException(TransitionNotAllowed::class);
 
         $model->state->transition(new CustomInvalidTransition($model));
+    }
+
+   /** @test */
+    public function test_custom_transition_blocks_can_transition_to()
+    {
+        $model = TestModelWithCustomTransition::create([
+            'state' => StateX::class,
+        ]);
+
+        $this->assertFalse($model->state->canTransitionTo(StateZ::class));
+    }
+
+   /** @test */
+    public function test_custom_transition_doesnt_block_can_transition_to()
+    {
+        $model = TestModelWithCustomTransition::create([
+            'state' => StateX::class,
+        ]);
+
+        $this->assertTrue($model->state->canTransitionTo(StateY::class));
     }
 
     /** @test */


### PR DESCRIPTION
Hi, I find it annoying that a transition can fail even though canTransitionTo returns true, so I have updated canTransitionTo to include a check for that.


NOTE this PR has no tests yet, but I'm happy to commit that time if you are interested in this PR.