### PR TITLE
Add base `getName` method to state classes.

### DIFF
--- a/src/State.php
+++ b/src/State.php
@@ -59,6 +59,11 @@ abstract class State implements Castable, JsonSerializable
         return static::$name ?? static::class;
     }
 
+    public static function getName(): ?string
+    {
+        return static::$name ?? null;
+    }
+
     public static function getStateMapping(): Collection
     {
         if (! isset(self::$stateMapping[static::class])) {
@@ -85,7 +90,7 @@ abstract class State implements Castable, JsonSerializable
 
             // Loose comparison is needed here in order to support non-string values,
             // Laravel casts their database value automatically to strings if we didn't specify the fields in `$casts`.
-            $name = isset($stateClass::$name) ? (string) $stateClass::$name : null;
+            $name = $stateClass::getName();
 
             if ($name == $state) {
                 return $stateClass;

--- a/tests/Dummy/ModelStates/StateE.php
+++ b/tests/Dummy/ModelStates/StateE.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\ModelStates;
+
+class StateE extends ModelState
+{
+    public static function getName(): string
+    {
+        return '5';
+    }
+}

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -8,6 +8,7 @@ use Spatie\ModelStates\Tests\Dummy\ModelStates\StateA;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateB;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateC;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateD;
+use Spatie\ModelStates\Tests\Dummy\ModelStates\StateE;
 use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateX;
 use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateY;
 use Spatie\ModelStates\Tests\Dummy\TestModel;
@@ -27,6 +28,8 @@ class StateTest extends TestCase
         $this->assertEquals(StateD::class, ModelState::resolveStateClass(StateD::class));
         $this->assertEquals(StateD::class, ModelState::resolveStateClass(StateD::getMorphClass()));
         $this->assertEquals(StateD::class, ModelState::resolveStateClass(StateD::$name));
+        $this->assertEquals(StateE::class, ModelState::resolveStateClass(StateE::class));
+        $this->assertEquals(StateE::class, ModelState::resolveStateClass(StateE::getMorphClass()));
     }
 
     /** @test */
@@ -102,6 +105,7 @@ class StateTest extends TestCase
                     StateB::getMorphClass(),
                     StateC::getMorphClass(),
                     StateD::getMorphClass(),
+                    StateE::getMorphClass(),
                 ],
             ],
             $states->toArray()
@@ -119,6 +123,7 @@ class StateTest extends TestCase
                 StateB::getMorphClass(),
                 StateC::getMorphClass(),
                 StateD::getMorphClass(),
+                StateE::getMorphClass(),
             ],
             $states->toArray()
         );
@@ -169,6 +174,7 @@ class StateTest extends TestCase
             StateB::getMorphClass() => StateB::class,
             StateC::getMorphClass() => StateC::class,
             StateD::getMorphClass() => StateD::class,
+            StateE::getMorphClass() => StateE::class,
         ], ModelState::all()->toArray());
     }
 


### PR DESCRIPTION
Allows the name to be defined through a method.

This is useful for setting a naming schema for a state through a method call. 

## Use case

For example, in my project I have a _lot_ of state classes for a state, but I don't want to store the FQCN in the database. I could do this by setting `public static $name` on each of my state classes, but given that all of my classes have a naming schema of just the class name but in snake case, this can prove to be time consuming.

This PR makes it possible to specify a convention via a method, such as this:

```php
public static function getName(): ?string
{
    return (string) Str::of(static::class)
        ->classBasename()
        ->snake();
}
```

## Background info

In my project I initially tried overriding `getMorphClass()` but this didn't work, as [this line](https://github.com/spatie/laravel-model-states/blob/c9c4865abd2b5ec534214aede784631366bed7d4/src/State.php#L88) in `resolveStateClass` doesn't use this value when resolving the class name.

```php
$name = isset($stateClass::$name) ? (string) $stateClass::$name : null;
```

I wasn't sure which approach was better, so I have #198 which solves this by using the `getMorphClass` method when resolving the class.