### PR TITLE
Update 03-listing-stated.md // Wrong namespace in the docs

### DIFF
--- a/docs/working-with-states/03-listing-states.md
+++ b/docs/working-with-states/03-listing-states.md
@@ -11,7 +11,7 @@ namespace App;
 use App\States\Invoice\Paid;
 use App\States\Invoice\Pending;
 use App\States\Invoice\Declined;
-use App\States\HasStates;
+use Spatie\ModelStates\HasStates;
 use App\States\Fulfillment\Partial;
 use App\States\Fulfillment\Complete;
 use App\States\Invoice\InvoiceState;


### PR DESCRIPTION
I think the namespace for the `HasStates` should be the from the spatie-package right? Hope I spotted that correctly.