### PR TITLE
Manually register concrete state classes

### DIFF
--- a/docs/working-with-states/01-configuring-states.md
+++ b/docs/working-with-states/01-configuring-states.md
@@ -100,4 +100,32 @@ abstract class PaymentState extends State
 }
 ```
 
+## Manually registering states
+If you want to place your concrete state implementations in a different directory, you may do so and register them manually:
+
+```php
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\StateConfig;
+
+use Your\Concrete\State\Class\Cancelled; // this may be wherever you want
+use Your\Concrete\State\Class\ExampleOne;
+use Your\Concrete\State\Class\ExampleTwo;
+
+abstract class PaymentState extends State
+{
+    abstract public function color(): string;
+    
+    public static function config(): StateConfig
+    {
+        return parent::config()
+            ->default(Pending::class)
+            ->allowTransition(Pending::class, Paid::class)
+            ->allowTransition(Pending::class, Failed::class)
+            ->registerState(Cancelled::class)
+            ->registerState([ExampleOne::class, ExampleTwo::class])
+        ;
+    }
+}
+```
+
 Next up, we'll take a moment to discuss how state classes are serialized to the database.

--- a/src/State.php
+++ b/src/State.php
@@ -300,6 +300,10 @@ abstract class State implements Castable, JsonSerializable
             $resolvedStates[$stateClass::getMorphClass()] = $stateClass;
         }
 
+        foreach ($stateConfig->registeredStates as $stateClass) {
+            $resolvedStates[$stateClass::getMorphClass()] = $stateClass;
+        }
+
         return $resolvedStates;
     }
 }

--- a/src/StateConfig.php
+++ b/src/StateConfig.php
@@ -15,6 +15,9 @@ class StateConfig
     /** @var string[] */
     public array $allowedTransitions = [];
 
+    /** @var string[] */
+    public array $registeredStates = [];
+
     public function __construct(
         string $baseStateClass
     ) {
@@ -93,6 +96,25 @@ class StateConfig
         }
 
         return $transitionableStates;
+    }
+
+    public function registerState($stateClass): StateConfig
+    {
+        if (is_array($stateClass)) {
+            foreach ($stateClass as $state) {
+                $this->registerState($state);
+            }
+
+            return $this;
+        }
+
+        if (!is_subclass_of($stateClass, $this->baseStateClass)) {
+            throw InvalidConfig::doesNotExtendBaseClass($stateClass, $this->baseStateClass);
+        }
+
+        $this->registeredStates[] = $stateClass;
+
+        return $this;
     }
 
     /**

--- a/tests/Dummy/ModelStates/AnotherDirectory/StateF.php
+++ b/tests/Dummy/ModelStates/AnotherDirectory/StateF.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory;
+
+use Spatie\ModelStates\Tests\Dummy\ModelStates\ModelState;
+
+class StateF extends ModelState
+{
+}

--- a/tests/Dummy/ModelStates/AnotherDirectory/StateG.php
+++ b/tests/Dummy/ModelStates/AnotherDirectory/StateG.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory;
+
+use Spatie\ModelStates\Tests\Dummy\ModelStates\ModelState;
+
+class StateG extends ModelState
+{
+    public static string $name = 'G';
+}

--- a/tests/Dummy/ModelStates/AnotherDirectory/StateH.php
+++ b/tests/Dummy/ModelStates/AnotherDirectory/StateH.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory;
+
+use Spatie\ModelStates\Tests\Dummy\ModelStates\ModelState;
+
+class StateH extends ModelState
+{
+    public static int $name = 8;
+}

--- a/tests/Dummy/ModelStates/ModelState.php
+++ b/tests/Dummy/ModelStates/ModelState.php
@@ -4,6 +4,9 @@ namespace Spatie\ModelStates\Tests\Dummy\ModelStates;
 
 use Spatie\ModelStates\State;
 use Spatie\ModelStates\StateConfig;
+use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateF;
+use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateG;
+use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateH;
 
 abstract class ModelState extends State
 {
@@ -13,6 +16,9 @@ abstract class ModelState extends State
             ->allowTransition(StateA::class, StateB::class)
             ->allowTransition([StateA::class, StateB::class], StateC::class)
             ->allowTransition(StateA::class, StateD::class)
+            ->allowTransition(StateA::class, StateF::class)
+            ->registerState(StateF::class)
+            ->registerState([StateG::class, StateH::class])
             ->default(StateA::class);
     }
 }

--- a/tests/StateCastingTest.php
+++ b/tests/StateCastingTest.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\DB;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\ModelState;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateA;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateC;
+use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateF;
+use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateG;
 use Spatie\ModelStates\Tests\Dummy\TestModel;
 
 class StateCastingTest extends TestCase
@@ -25,6 +27,20 @@ class StateCastingTest extends TestCase
     }
 
     /** @test */
+    public function custom_registered_state_without_alias_is_serialized_on_create()
+    {
+        $model = TestModel::create([
+            'state' => StateF::class,
+        ]);
+
+        $this->assertInstanceOf(StateF::class, $model->state);
+
+        $this->assertDatabaseHas($model->getTable(), [
+            'state' => StateF::getMorphClass(),
+        ]);
+    }
+
+    /** @test */
     public function state_with_alias_is_serialized_on_create_when_using_class_name()
     {
         $model = TestModel::create([
@@ -39,6 +55,20 @@ class StateCastingTest extends TestCase
     }
 
     /** @test */
+    public function custom_registered_state_with_alias_is_serialized_on_create_when_using_class_name()
+    {
+        $model = TestModel::create([
+            'state' => StateG::class,
+        ]);
+
+        $this->assertInstanceOf(StateG::class, $model->state);
+
+        $this->assertDatabaseHas($model->getTable(), [
+            'state' => StateG::getMorphClass(),
+        ]);
+    }
+
+    /** @test */
     public function state_with_alias_is_serialized_on_create_when_using_alias()
     {
         $model = TestModel::create([
@@ -49,6 +79,20 @@ class StateCastingTest extends TestCase
 
         $this->assertDatabaseHas($model->getTable(), [
             'state' => StateC::getMorphClass(),
+        ]);
+    }
+
+    /** @test */
+    public function custom_registered_state_with_alias_is_serialized_on_create_when_using_alias()
+    {
+        $model = TestModel::create([
+            'state' => StateG::getMorphClass(),
+        ]);
+
+        $this->assertInstanceOf(StateG::class, $model->state);
+
+        $this->assertDatabaseHas($model->getTable(), [
+            'state' => StateG::getMorphClass(),
         ]);
     }
 

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -9,6 +9,9 @@ use Spatie\ModelStates\Tests\Dummy\ModelStates\StateB;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateC;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateD;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateE;
+use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateF;
+use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateG;
+use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateH;
 use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateX;
 use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateY;
 use Spatie\ModelStates\Tests\Dummy\TestModel;
@@ -30,6 +33,11 @@ class StateTest extends TestCase
         $this->assertEquals(StateD::class, ModelState::resolveStateClass(StateD::$name));
         $this->assertEquals(StateE::class, ModelState::resolveStateClass(StateE::class));
         $this->assertEquals(StateE::class, ModelState::resolveStateClass(StateE::getMorphClass()));
+        $this->assertEquals(StateF::class, ModelState::resolveStateClass(StateF::getMorphClass()));
+        $this->assertEquals(StateG::class, ModelState::resolveStateClass(StateG::getMorphClass()));
+        $this->assertEquals(StateG::class, ModelState::resolveStateClass(StateG::getMorphClass()));
+        $this->assertEquals(StateH::class, ModelState::resolveStateClass(StateH::getMorphClass()));
+        $this->assertEquals(StateH::class, ModelState::resolveStateClass(StateH::getMorphClass()));
     }
 
     /** @test */
@@ -41,6 +49,7 @@ class StateTest extends TestCase
             StateB::getMorphClass(),
             StateC::getMorphClass(),
             StateD::getMorphClass(),
+            StateF::getMorphClass(),
         ], $modelA->state->transitionableStates());
 
         $modelB = TestModelWithDefault::create([
@@ -85,6 +94,7 @@ class StateTest extends TestCase
 
         $this->assertTrue($state->canTransitionTo(StateB::class));
         $this->assertTrue($state->canTransitionTo(StateC::class));
+        $this->assertTrue($state->canTransitionTo(StateF::class));
 
         $state = new StateB(new TestModel());
         $state->setField('state');
@@ -106,6 +116,9 @@ class StateTest extends TestCase
                     StateC::getMorphClass(),
                     StateD::getMorphClass(),
                     StateE::getMorphClass(),
+                    StateF::getMorphClass(),
+                    StateG::getMorphClass(),
+                    StateH::getMorphClass(),
                 ],
             ],
             $states->toArray()
@@ -124,6 +137,9 @@ class StateTest extends TestCase
                 StateC::getMorphClass(),
                 StateD::getMorphClass(),
                 StateE::getMorphClass(),
+                StateF::getMorphClass(),
+                StateG::getMorphClass(),
+                StateH::getMorphClass(),
             ],
             $states->toArray()
         );
@@ -175,6 +191,9 @@ class StateTest extends TestCase
             StateC::getMorphClass() => StateC::class,
             StateD::getMorphClass() => StateD::class,
             StateE::getMorphClass() => StateE::class,
+            StateF::getMorphClass() => StateF::class,
+            StateG::getMorphClass() => StateG::class,
+            StateH::getMorphClass() => StateH::class,
         ], ModelState::all()->toArray());
     }
 


### PR DESCRIPTION
Added a `registerState($stateClass)` method on the `StateConfig` class to be able to include concrete state implementations other than the ones in the same directory as the abstract base class.

Implementing the functionality asked in [this discussion](https://github.com/spatie/laravel-model-states/discussions/202).

Also added what I considered relevant tests, and a subsection with the new functionality in the docs.