### PR TITLE
Ensures field is always set when changing states

### DIFF
--- a/src/StateCaster.php
+++ b/src/StateCaster.php
@@ -63,6 +63,10 @@ class StateCaster implements CastsAttributes
             $value = $mapping[$value];
         }
 
+        if ($value instanceof $this->baseStateClass) {
+            $value->setField($key);
+        }
+
         return $value::getMorphClass();
     }
 

--- a/tests/StateCastingTest.php
+++ b/tests/StateCastingTest.php
@@ -5,6 +5,7 @@ namespace Spatie\ModelStates\Tests;
 use Illuminate\Support\Facades\DB;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\ModelState;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateA;
+use Spatie\ModelStates\Tests\Dummy\ModelStates\StateB;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateC;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateF;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateG;
@@ -146,5 +147,19 @@ class StateCastingTest extends TestCase
         $this->assertDatabaseHas($model->getTable(), [
             'state' => StateA::getMorphClass(),
         ]);
+    }
+
+    /** @test */
+    public function field_is_always_populated_when_set()
+    {
+        $model = new TestModel();
+
+        $this->assertInstanceOf(StateA::class, $model->state);
+
+        $model->state = new StateB($model);
+
+        $this->assertInstanceOf(StateB::class, $model->state);
+
+        $this->assertEquals('state', $model->state->getField());
     }
 }


### PR DESCRIPTION
When changing state the "Field" property is not always set

eg.
```php
$model->state = new StageB($model);

$model->state->getField() // Throws Error: Typed property Spatie\ModelStates\State::$field must not be accessed before initialization
```

This can cause errors if you perform an action such as `$model->state->transitionableStates()` straight after setting the value.

This fixes that but always setting the "Field" property in the "set" part of the caster