### PR TITLE
Removed Model type enforcement and replaced with PHPDoc

### DIFF
--- a/src/DefaultTransition.php
+++ b/src/DefaultTransition.php
@@ -2,18 +2,21 @@
 
 namespace Spatie\ModelStates;
 
-use Illuminate\Database\Eloquent\Model;
-
 class DefaultTransition extends Transition
 {
-    protected Model $model;
+    protected $model;
 
     protected string $field;
 
     protected State $newState;
 
+    /**
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $field
+     * @param  State  $newState
+     */
     public function __construct(
-        Model $model,
+        $model,
         string $field,
         State $newState
     ) {
@@ -22,7 +25,10 @@ class DefaultTransition extends Transition
         $this->newState = $newState;
     }
 
-    public function handle(): Model
+    /**
+     * @return  \Illuminate\Database\Eloquent\Model
+     */
+    public function handle()
     {
         $originalState = $this->model->{$this->field} ? clone $this->model->{$this->field} : null;
 

--- a/src/Events/StateChanged.php
+++ b/src/Events/StateChanged.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\ModelStates\Events;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\SerializesModels;
 use Spatie\ModelStates\State;
 use Spatie\ModelStates\Transition;
@@ -17,13 +16,19 @@ class StateChanged
 
     public Transition $transition;
 
-    public Model $model;
+    public $model;
 
+    /**
+     * @param  string|State|null  $initialState
+     * @param  string|State|null  $finalState
+     * @param  Transition  $finalState
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     */
     public function __construct(
         ?State $initialState,
         ?State $finalState,
         Transition $transition,
-        Model $model
+        $model
     ) {
         $this->initialState = $initialState;
         $this->finalState = $finalState;

--- a/src/Exceptions/CouldNotPerformTransition.php
+++ b/src/Exceptions/CouldNotPerformTransition.php
@@ -3,11 +3,15 @@
 namespace Spatie\ModelStates\Exceptions;
 
 use Exception;
-use Illuminate\Database\Eloquent\Model;
 
 class CouldNotPerformTransition extends Exception
 {
-    public static function notAllowed(Model $model, $transitionClass): CouldNotPerformTransition
+    /**
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  Transition  $transitionClass
+     * @return  CouldNotPerformTransition
+     */
+    public static function notAllowed($model, $transitionClass): CouldNotPerformTransition
     {
         $modelClass = get_class($model);
 
@@ -16,14 +20,24 @@ class CouldNotPerformTransition extends Exception
         return TransitionNotAllowed::make($modelClass, $transitionClass);
     }
 
-    public static function notFound(string $from, string $to, Model $model): CouldNotPerformTransition
+    /**
+     * @param  string  $from
+     * @param  string  $to
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return  CouldNotPerformTransition
+     */
+    public static function notFound(string $from, string $to, $model): CouldNotPerformTransition
     {
         $modelClass = get_class($model);
 
         return TransitionNotFound::make($from, $to, $modelClass);
     }
 
-    public static function couldNotResolveTransitionField(Model $model): CouldNotPerformTransition
+    /**
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return  CouldNotPerformTransition
+     */
+    public static function couldNotResolveTransitionField($model): CouldNotPerformTransition
     {
         $modelClass = get_class($model);
 

--- a/src/Exceptions/InvalidConfig.php
+++ b/src/Exceptions/InvalidConfig.php
@@ -3,14 +3,18 @@
 namespace Spatie\ModelStates\Exceptions;
 
 use Exception;
-use Illuminate\Database\Eloquent\Model;
 use Spatie\ModelStates\HasStates;
 use Spatie\ModelStates\State;
 use Spatie\ModelStates\Transition;
 
 class InvalidConfig extends Exception
 {
-    public static function fieldNotFound(string $fieldName, Model $model): InvalidConfig
+    /**
+     * @param  string  $fieldName
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return  InvalidConfig
+     */
+    public static function fieldNotFound(string $fieldName, $model): InvalidConfig
     {
         $modelClass = get_class($model);
 
@@ -37,7 +41,11 @@ class InvalidConfig extends Exception
         return ClassDoesNotExtendBaseClass::make($class, $baseClass);
     }
 
-    public static function resolveTransitionNotFound(Model $model): InvalidConfig
+    /**
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return  InvalidConfig
+     */
+    public static function resolveTransitionNotFound($model): InvalidConfig
     {
         $modelClass = get_class($model);
 

--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -3,7 +3,6 @@
 namespace Spatie\ModelStates;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -14,7 +13,7 @@ trait HasStates
 
     public static function bootHasStates(): void
     {
-        self::creating(function (Model $model) {
+        self::creating(function ($model) {
             /**
              * @var \Spatie\ModelStates\HasStates $model
              */

--- a/src/State.php
+++ b/src/State.php
@@ -3,7 +3,6 @@
 namespace Spatie\ModelStates;
 
 use Illuminate\Contracts\Database\Eloquent\Castable;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use JsonSerializable;
 use ReflectionClass;
@@ -14,7 +13,7 @@ use Spatie\ModelStates\Exceptions\InvalidConfig;
 
 abstract class State implements Castable, JsonSerializable
 {
-    private Model $model;
+    private $model;
 
     private StateConfig $stateConfig;
 
@@ -22,7 +21,10 @@ abstract class State implements Castable, JsonSerializable
 
     private static array $stateMapping = [];
 
-    public function __construct(Model $model)
+    /**
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     */
+    public function __construct($model)
     {
         $this->model = $model;
         $this->stateConfig = static::config();
@@ -95,7 +97,12 @@ abstract class State implements Castable, JsonSerializable
         return $state;
     }
 
-    public static function make(string $name, Model $model): State
+    /**
+     * @param  string  $name
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return  State
+     */
+    public static function make(string $name, $model): State
     {
         $stateClass = static::resolveStateClass($name);
 
@@ -106,7 +113,10 @@ abstract class State implements Castable, JsonSerializable
         return new $stateClass($model);
     }
 
-    public function getModel(): Model
+    /**
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function getModel()
     {
         return $this->model;
     }
@@ -131,7 +141,12 @@ abstract class State implements Castable, JsonSerializable
         return $this;
     }
 
-    public function transitionTo($newState, ...$transitionArgs): Model
+    /**
+     * @param  string|State  $newState
+     * @param  mixed  ...$transitionArgs
+     * @return  \Illuminate\Database\Eloquent\Model
+     */
+    public function transitionTo($newState, ...$transitionArgs)
     {
         $newState = $this->resolveStateObject($newState);
 
@@ -153,7 +168,11 @@ abstract class State implements Castable, JsonSerializable
         return $this->transition($transition);
     }
 
-    public function transition(Transition $transition): Model
+    /**
+     * @param  Transition  $transition
+     * @return  \Illuminate\Database\Eloquent\Model
+     */
+    public function transition(Transition $transition)
     {
         if (method_exists($transition, 'canTransition')) {
             if (! $transition->canTransition()) {

--- a/tests/Dummy/Transitions/CustomDefaultTransition.php
+++ b/tests/Dummy/Transitions/CustomDefaultTransition.php
@@ -2,12 +2,14 @@
 
 namespace Spatie\ModelStates\Tests\Dummy\Transitions;
 
-use Illuminate\Database\Eloquent\Model;
 use Spatie\ModelStates\DefaultTransition;
 
 class CustomDefaultTransition extends DefaultTransition
 {
-    public function handle(): Model
+    /**
+     * @return  \Illuminate\Database\Eloquent\Model
+     */
+    public function handle()
     {
         $originalState = $this->model->{$this->field} ? clone $this->model->{$this->field} : null;
 


### PR DESCRIPTION
Hello.

I have have been using this library in my project and it's great!

In my project i'm also working with classes wich act like Eloquent's models but aren't strictly that type (due to the complexity of satisfying the Model class).

This library works great also in this situation but i've had to remove the PHP strict type defininitions.

Interestingly this is also how Laravel defines the CastInboundInterface, by using PHPdoc instead of strict types.
I assume it must be done for this reason?

```PHP
//from Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes
interface CastsInboundAttributes
{
    /**
     * Transform the attribute to its underlying model values.
     *
     * @param  \Illuminate\Database\Eloquent\Model  $model
     * @param  string  $key
     * @param  mixed  $value
     * @param  array  $attributes
     * @return mixed
     */
    public function set($model, string $key, $value, array $attributes);
}
```

Thanks for your time:


