### PR TITLE
Equalize DefaultTransition and custom Transitions constructors

### DIFF
--- a/src/DefaultTransition.php
+++ b/src/DefaultTransition.php
@@ -11,18 +11,14 @@ class DefaultTransition extends Transition
     protected State $newState;
 
     /**
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  TransitionContext  $model
      * @param  string  $field
      * @param  State  $newState
      */
-    public function __construct(
-        $model,
-        string $field,
-        State $newState
-    ) {
-        $this->model = $model;
-        $this->field = $field;
-        $this->newState = $newState;
+    public function __construct($transitionContext, ...$transitionArgs) {
+        $this->model = $transitionContext->model;
+        $this->field = $transitionContext->field;
+        $this->newState = $transitionContext->newState;
     }
 
     /**

--- a/src/State.php
+++ b/src/State.php
@@ -279,12 +279,22 @@ abstract class State implements Castable, JsonSerializable
             $defaultTransition = config('model-states.default_transition', DefaultTransition::class);
 
             $transition = new $defaultTransition(
-                $this->model,
-                $this->field,
-                $newState
+                new TransitionContext(
+                    $this->model,
+                    $this->field,
+                    $newState,
+                ),
+                ...$transitionArgs
             );
         } else {
-            $transition = new $transitionClass($this->model, ...$transitionArgs);
+            $transition = new $transitionClass(
+                new TransitionContext(
+                    $this->model,
+                    $this->field,
+                    $newState,
+                ),
+                ...$transitionArgs
+            );
         }
 
         return $transition;

--- a/src/TransitionContext.php
+++ b/src/TransitionContext.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\ModelStates;
+
+class TransitionContext {
+
+    public $model;
+
+    public string $field;
+
+    public State $newState;
+
+    public State $oldState;
+
+    /**
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $field
+     * @param  State  $newState
+     */
+    public function __construct($model, string $field, State $newState) {
+        $this->model = $model;
+        $this->field = $field;
+        $this->newState = $newState;
+        $this->oldState = $model->{$this->field};
+    }
+}

--- a/tests/AttributeStateTest.php
+++ b/tests/AttributeStateTest.php
@@ -7,7 +7,7 @@ use Spatie\ModelStates\Tests\Dummy\AttributeState\AttributeStateB;
 use Spatie\ModelStates\Tests\Dummy\AttributeState\AttributeStateTransition;
 use Spatie\ModelStates\Tests\Dummy\AttributeState\TestModelWithAttributeState;
 
-class AttributeSateTest extends TestCase
+class AttributeStateTest extends TestCase
 {
     /** @test */
     public function test_default()

--- a/tests/Dummy/AttributeState/AttributeStateTransition.php
+++ b/tests/Dummy/AttributeState/AttributeStateTransition.php
@@ -3,6 +3,7 @@
 namespace Spatie\ModelStates\Tests\Dummy\AttributeState;
 
 use Spatie\ModelStates\Transition;
+use Spatie\ModelStates\TransitionContext;
 
 class AttributeStateTransition extends Transition
 {
@@ -10,11 +11,15 @@ class AttributeStateTransition extends Transition
 
     private TestModelWithAttributeState $model;
 
-    public function __construct(TestModelWithAttributeState $model)
+    public function __construct(TestModelWithAttributeState|TransitionContext $model)
     {
         self::$transitioned = false;
 
-        $this->model = $model;
+        if ($model instanceof TransitionContext) {
+            $this->model = $model->model;
+        } else {
+            $this->model = $model;
+        }
     }
 
     public function handle(): TestModelWithAttributeState

--- a/tests/Dummy/Transitions/CustomInvalidTransition.php
+++ b/tests/Dummy/Transitions/CustomInvalidTransition.php
@@ -2,20 +2,29 @@
 
 namespace Spatie\ModelStates\Tests\Dummy\Transitions;
 
+use PHPUnit\Framework\Assert;
+use Spatie\ModelStates\State;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithCustomTransition;
 use Spatie\ModelStates\Transition;
+use Spatie\ModelStates\TransitionContext;
 
 class CustomInvalidTransition extends Transition
 {
     private TestModelWithCustomTransition $model;
 
-    public function __construct(TestModelWithCustomTransition $model)
+    public function __construct($model, ...$transitionArgs)
     {
-        $this->model = $model;
+        if ($model instanceof TransitionContext) {
+            $this->model = $model->model;
+        } else {
+            $this->model = $model;
+        }
     }
 
     public function canTransition(): bool
     {
+        Assert::assertInstanceOf(TestModelWithCustomTransition::class, $this->model);
+
         return false;
     }
 }

--- a/tests/Dummy/Transitions/CustomTransition.php
+++ b/tests/Dummy/Transitions/CustomTransition.php
@@ -3,10 +3,12 @@
 namespace Spatie\ModelStates\Tests\Dummy\Transitions;
 
 use PHPUnit\Framework\Assert;
+use Spatie\ModelStates\State;
 use Spatie\ModelStates\Tests\Dummy\DummyDependency;
 use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateY;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithCustomTransition;
 use Spatie\ModelStates\Transition;
+use Spatie\ModelStates\TransitionContext;
 
 class CustomTransition extends Transition
 {
@@ -14,9 +16,14 @@ class CustomTransition extends Transition
 
     private string $message;
 
-    public function __construct(TestModelWithCustomTransition $model, ...$transitionArgs)
+
+    public function __construct($model, ...$transitionArgs)
     {
-        $this->model = $model;
+        if ($model instanceof TransitionContext) {
+            $this->model = $model->model;
+        } else {
+            $this->model = $model;
+        }
 
         if (array_key_exists(0, $transitionArgs)) {
             $this->message = $transitionArgs[0];
@@ -26,6 +33,8 @@ class CustomTransition extends Transition
     public function handle(DummyDependency $dummyDependency): TestModelWithCustomTransition
     {
         Assert::assertNotNull($dummyDependency);
+        Assert::assertInstanceOf(TestModelWithCustomTransition::class, $this->model);
+
 
         $this->model->fill([
             'state' => StateY::class,


### PR DESCRIPTION
Hello again.

This should be the last pull request i need to do. :smile:

I'm sorta confused by the behaviour of `resolveTransitionClass()` currently.

Why doesn't a custom transition gets the same parameters as the default one and vice versa?

Also i don't see currently how a custom transition can advance to the newState as it's not passed to it.
I suppose this is because it's possibly not intended to write a generic custom transition? As in a custom transition should have an hardcoded target state.

Could you shed some light on this? maybe i'm taking the wrong approach.
Feel free to look at my proposed change.

This if it gets merged should possibly require a major version since i'm changing the constructors and could break existing people's code.

Thanks again for your help.



