### PR TITLE
Recommend not to use hypens in the name

### DIFF
--- a/docs/working-with-states/02-serializing-states.md
+++ b/docs/working-with-states/02-serializing-states.md
@@ -11,7 +11,7 @@ $payment = Payment::create();
 
 If you've setup the default state to be `Pending`, this `state` field in the database will contain the class name of this state, eg. `\App\States\Payment\Pending`.
 
-Chances are you don't want to work directly with a state's class name all the time. This is why you may add a static `$name` property on each state class, which will be used to serialize the state instead.
+Chances are you don't want to work directly with a state's class name all the time. This is why you may add a static `$name` property on each state class, which will be used to serialize the state instead. Do not use a hyphen(-) as this will conflict with internal naming conventions.
 
 ```php
 class Paid extends PaymentState


### PR DESCRIPTION
Hypens conflict with finding the transitionable states as they are used in the allowed transitions keys in the StateConfig class, they look something like 'fromState-toState', and this string is exploded at the hypen. If you have a hypen in the name, like "from-state-to-state" we confuse the system as the hyphen wont divide the class into valid states. (view StateConfig class, line 89).