### PR TITLE
Add missing `RegisterState` Attribute

### DIFF
--- a/docs/working-with-states/01-configuring-states.md
+++ b/docs/working-with-states/01-configuring-states.md
@@ -83,23 +83,6 @@ abstract class PaymentState extends State
 }
 ```
 
-If you're using PHP 8 or higher, you can also configure your state using attributes:
-
-```php
-use Spatie\ModelStates\Attributes\AllowTransition;
-use Spatie\ModelStates\State;
-
-#[
-    AllowTransition(Pending::class, Paid::class),
-    AllowTransition(Pending::class, Failed::class),
-    DefaultState(Pending::class),
-]
-abstract class PaymentState extends State
-{
-    abstract public function color(): string;
-}
-```
-
 ## Manually registering states
 If you want to place your concrete state implementations in a different directory, you may do so and register them manually:
 
@@ -125,6 +108,27 @@ abstract class PaymentState extends State
             ->registerState([ExampleOne::class, ExampleTwo::class])
         ;
     }
+}
+```
+
+## Configuring states using attributes
+
+If you're using PHP 8 or higher, you can also configure your state using attributes:
+
+```php
+use Spatie\ModelStates\Attributes\AllowTransition;
+use Spatie\ModelStates\Attributes\RegisterState;use Spatie\ModelStates\State;use const Grpc\STATUS_CANCELLED;
+
+#[
+    AllowTransition(Pending::class, Paid::class),
+    AllowTransition(Pending::class, Failed::class),
+    DefaultState(Pending::class),
+    RegisterState(Cancelled::class),
+    RegisterState([ExampleOne::class, ExampleTwo::class]),
+]
+abstract class PaymentState extends State
+{
+    abstract public function color(): string;
 }
 ```
 

--- a/src/Attributes/AttributeLoader.php
+++ b/src/Attributes/AttributeLoader.php
@@ -35,7 +35,17 @@ class AttributeLoader
 
             $stateConfig->default($defaultStateAttribute->defaultStateClass);
         }
-
-        return $stateConfig;
+	
+	    $registerStateAttributes = $this->reflectionClass->getAttributes(RegisterState::class);
+		
+		foreach($registerStateAttributes as $attribute) {
+			/** @var \Spatie\ModelStates\Attributes\RegisterState $registerStateAttribute */
+			$registerStateAttribute = $attribute->newInstance();
+			
+			$stateConfig->registerState($registerStateAttribute->stateClass);
+		}
+	
+	
+	    return $stateConfig;
     }
 }

--- a/src/Attributes/RegisterState.php
+++ b/src/Attributes/RegisterState.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\ModelStates\Attributes;
+
+use Attribute;
+use JetBrains\PhpStorm\Immutable;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class RegisterState
+{
+    public function __construct(
+        #[Immutable] public string|array $stateClass,
+    ) {
+    }
+}

--- a/tests/AttributeStateTest.php
+++ b/tests/AttributeStateTest.php
@@ -2,12 +2,15 @@
 
 namespace Spatie\ModelStates\Tests;
 
+use Spatie\ModelStates\Tests\Dummy\AttributeState\AnotherDirectory\AttributeStateC;
+use Spatie\ModelStates\Tests\Dummy\AttributeState\AnotherDirectory\AttributeStateD;
+use Spatie\ModelStates\Tests\Dummy\AttributeState\AnotherDirectory\AttributeStateE;
 use Spatie\ModelStates\Tests\Dummy\AttributeState\AttributeStateA;
 use Spatie\ModelStates\Tests\Dummy\AttributeState\AttributeStateB;
 use Spatie\ModelStates\Tests\Dummy\AttributeState\AttributeStateTransition;
 use Spatie\ModelStates\Tests\Dummy\AttributeState\TestModelWithAttributeState;
 
-class AttributeSateTest extends TestCase
+class AttributeStateTest extends TestCase
 {
     /** @test */
     public function test_default()
@@ -39,4 +42,25 @@ class AttributeSateTest extends TestCase
         $this->assertTrue($model->state->equals(AttributeStateB::class));
         $this->assertTrue(AttributeStateTransition::$transitioned);
     }
+	
+	/** @test */
+	public function test_registered_states()
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Not PHP 8');
+			
+			return;
+		}
+		
+		$model = new TestModelWithAttributeState();
+		
+		$this->assertSame([AttributeStateC::class, AttributeStateD::class, AttributeStateE::class], AttributeStateA::config()->registeredStates);
+		$this->assertSame([AttributeStateC::class, AttributeStateD::class, AttributeStateE::class], AttributeStateC::config()->registeredStates);
+		
+		$this->assertTrue($model->state->equals(AttributeStateA::class));
+		
+		$model->state->transitionTo(AttributeStateC::class);
+		
+		$this->assertTrue($model->state->equals(AttributeStateC::class));
+	}
 }

--- a/tests/Dummy/AttributeState/AnotherDirectory/AttributeStateC.php
+++ b/tests/Dummy/AttributeState/AnotherDirectory/AttributeStateC.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AttributeState\AnotherDirectory;
+
+use Spatie\ModelStates\Tests\Dummy\AttributeState\AttributeState;
+
+class AttributeStateC extends AttributeState
+{
+}

--- a/tests/Dummy/AttributeState/AnotherDirectory/AttributeStateD.php
+++ b/tests/Dummy/AttributeState/AnotherDirectory/AttributeStateD.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AttributeState\AnotherDirectory;
+
+use Spatie\ModelStates\Tests\Dummy\AttributeState\AttributeState;
+
+class AttributeStateD extends AttributeState
+{
+}

--- a/tests/Dummy/AttributeState/AnotherDirectory/AttributeStateE.php
+++ b/tests/Dummy/AttributeState/AnotherDirectory/AttributeStateE.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AttributeState\AnotherDirectory;
+
+use Spatie\ModelStates\Tests\Dummy\AttributeState\AttributeState;
+
+class AttributeStateE extends AttributeState
+{
+}

--- a/tests/Dummy/AttributeState/AnotherDirectory/AttributeStateF.php
+++ b/tests/Dummy/AttributeState/AnotherDirectory/AttributeStateF.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AttributeState\AnotherDirectory;
+
+use Spatie\ModelStates\Tests\Dummy\AttributeState\AttributeState;
+
+class AttributeStateF extends AttributeState
+{
+}

--- a/tests/Dummy/AttributeState/AttributeState.php
+++ b/tests/Dummy/AttributeState/AttributeState.php
@@ -4,12 +4,19 @@ namespace Spatie\ModelStates\Tests\Dummy\AttributeState;
 
 use Spatie\ModelStates\Attributes\AllowTransition;
 use Spatie\ModelStates\Attributes\DefaultState;
+use Spatie\ModelStates\Attributes\RegisterState;
 use Spatie\ModelStates\State;
+use Spatie\ModelStates\Tests\Dummy\AttributeState\AnotherDirectory\AttributeStateC;
+use Spatie\ModelStates\Tests\Dummy\AttributeState\AnotherDirectory\AttributeStateD;
+use Spatie\ModelStates\Tests\Dummy\AttributeState\AnotherDirectory\AttributeStateE;
 
 #[
     AllowTransition(AttributeStateA::class, AttributeStateB::class, AttributeStateTransition::class),
     AllowTransition(AttributeStateB::class, AttributeStateA::class),
+    AllowTransition(AttributeStateA::class, AttributeStateC::class),
     DefaultState(AttributeStateA::class),
+	RegisterState(AttributeStateC::class),
+	RegisterState([AttributeStateD::class, AttributeStateE::class]),
 ]
 abstract class AttributeState extends State
 {


### PR DESCRIPTION
This PR adds a missing attribute called `RegisterState`, in addition to the `AllowTransition` and `DefaultState` attribute. Before, it was only possible to register states using the `->registerState()` in the config, whilst the transition and default state configs had their own attribute.

With this PR, people can now completely configure their states using attributes.

Thanks!