### PR TITLE
Option to skip automatic scan of directory for states

### DIFF
--- a/docs/working-with-states/01-configuring-states.md
+++ b/docs/working-with-states/01-configuring-states.md
@@ -111,6 +111,8 @@ abstract class PaymentState extends State
 }
 ```
 
+In case you want to register all your states manually, you can disable the automatic registration of states by calling `skipAutoRegisterStates()`!
+
 ## Configuring states using attributes
 
 If you're using PHP 8 or higher, you can also configure your state using attributes:

--- a/src/Exceptions/CouldNotPerformTransition.php
+++ b/src/Exceptions/CouldNotPerformTransition.php
@@ -3,6 +3,7 @@
 namespace Spatie\ModelStates\Exceptions;
 
 use Exception;
+use Spatie\ModelStates\Transition;
 
 class CouldNotPerformTransition extends Exception
 {

--- a/src/State.php
+++ b/src/State.php
@@ -293,9 +293,11 @@ abstract class State implements Castable, JsonSerializable
     private static function resolveStateMapping(): array
     {
         $resolvedStates = [];
-        
-        if (empty($stateConfig->registeredStates)){
-        
+
+        $stateConfig = static::config();
+
+        if ($stateConfig->autoRegisterStates) {
+
             $reflection = new ReflectionClass(static::class);
 
             ['dirname' => $directory] = pathinfo($reflection->getFileName());
@@ -306,7 +308,6 @@ abstract class State implements Castable, JsonSerializable
 
 
 
-            $stateConfig = static::config();
 
             foreach ($files as $file) {
                 if ($file === '.' || $file === '..') {

--- a/src/StateConfig.php
+++ b/src/StateConfig.php
@@ -18,6 +18,8 @@ class StateConfig
     /** @var string[] */
     public array $registeredStates = [];
 
+    public bool $autoRegisterStates = true;
+
     public function __construct(
         string $baseStateClass
     ) {
@@ -115,6 +117,18 @@ class StateConfig
         $this->registeredStates[] = $stateClass;
 
         return $this;
+    }
+
+    public function autoRegisterStates(bool $autoRegisterStates = true): StateConfig
+    {
+        $this->autoRegisterStates = $autoRegisterStates;
+
+        return $this;
+    }
+
+    public function skipAutoRegisterStates(): StateConfig
+    {
+        return $this->autoRegisterStates(false);
     }
 
     /**

--- a/tests/Dummy/ModelStatesWithoutAutoRegister/AnotherDirectory/StateF.php
+++ b/tests/Dummy/ModelStatesWithoutAutoRegister/AnotherDirectory/StateF.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\ModelStatesWithoutAutoRegister\AnotherDirectory;
+
+use Spatie\ModelStates\Tests\Dummy\ModelStatesWithoutAutoRegister\ModelStateWithoutAutoRegister;
+
+class StateF extends ModelStateWithoutAutoRegister
+{
+}

--- a/tests/Dummy/ModelStatesWithoutAutoRegister/ModelStateWithoutAutoRegister.php
+++ b/tests/Dummy/ModelStatesWithoutAutoRegister/ModelStateWithoutAutoRegister.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\ModelStatesWithoutAutoRegister;
+
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\StateConfig;
+use Spatie\ModelStates\Tests\Dummy\ModelStatesWithoutAutoRegister\AnotherDirectory\StateF;
+
+
+abstract class ModelStateWithoutAutoRegister extends State
+{
+
+    public static function config(): StateConfig
+    {
+        return parent::config()
+            ->allowTransition(StateA::class, StateB::class)
+            ->registerState(StateF::class)
+            ->registerState([StateA::class, StateB::class])
+            ->default(StateA::class)
+            ->skipAutoRegisterStates();
+    }
+
+}

--- a/tests/Dummy/ModelStatesWithoutAutoRegister/StateA.php
+++ b/tests/Dummy/ModelStatesWithoutAutoRegister/StateA.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\ModelStatesWithoutAutoRegister;
+
+class StateA extends ModelStateWithoutAutoRegister
+{
+}

--- a/tests/Dummy/ModelStatesWithoutAutoRegister/StateB.php
+++ b/tests/Dummy/ModelStatesWithoutAutoRegister/StateB.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\ModelStatesWithoutAutoRegister;
+
+class StateB extends ModelStateWithoutAutoRegister
+{
+}

--- a/tests/Dummy/ModelStatesWithoutAutoRegister/StateD.php
+++ b/tests/Dummy/ModelStatesWithoutAutoRegister/StateD.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\ModelStatesWithoutAutoRegister;
+
+
+class StateD extends ModelStateWithoutAutoRegister
+{
+    public static int $name = 4;
+}

--- a/tests/Dummy/ModelStatesWithoutAutoRegister/StateD.php
+++ b/tests/Dummy/ModelStatesWithoutAutoRegister/StateD.php
@@ -2,8 +2,6 @@
 
 namespace Spatie\ModelStates\Tests\Dummy\ModelStatesWithoutAutoRegister;
 
-
 class StateD extends ModelStateWithoutAutoRegister
 {
-    public static int $name = 4;
 }

--- a/tests/Dummy/TestModelWithoutAutoRegistration.php
+++ b/tests/Dummy/TestModelWithoutAutoRegistration.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy;
+
+use Spatie\ModelStates\Tests\Dummy\ModelStatesWithoutAutoRegister\ModelStateWithoutAutoRegister;
+
+class TestModelWithoutAutoRegistration extends TestModel
+{
+    protected $casts = [
+        'state' => ModelStateWithoutAutoRegister::class,
+    ];
+}

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -114,6 +114,7 @@ it('get states', function () {
 it('get states without auto-registration', function () {
     $states = TestModelWithoutAutoRegistration::getStates();
 
+    // Expectation is for StateD NOT to be registered as it is in the folder but never loaded
     expect(
         [
             'state' => [

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -16,6 +16,7 @@ use Spatie\ModelStates\Tests\Dummy\TestModel;
 use Spatie\ModelStates\Tests\Dummy\TestModelUpdatingEvent;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithCustomTransition;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithDefault;
+use Spatie\ModelStates\Tests\Dummy\TestModelWithoutAutoRegistration;
 
 it('resolve state class', function () {
     expect(ModelState::resolveStateClass(StateA::class))->toEqual(StateA::class);
@@ -105,6 +106,20 @@ it('get states', function () {
                 StateF::getMorphClass(),
                 StateG::getMorphClass(),
                 StateH::getMorphClass(),
+            ],
+        ],
+    )->toEqual($states->toArray());
+});
+
+it('get states without auto-registration', function () {
+    $states = TestModelWithoutAutoRegistration::getStates();
+
+    expect(
+        [
+            'state' => [
+                \Spatie\ModelStates\Tests\Dummy\ModelStatesWithoutAutoRegister\AnotherDirectory\StateF::getMorphClass(),
+                \Spatie\ModelStates\Tests\Dummy\ModelStatesWithoutAutoRegister\StateA::getMorphClass(),
+                \Spatie\ModelStates\Tests\Dummy\ModelStatesWithoutAutoRegister\StateB::getMorphClass(),
             ],
         ],
     )->toEqual($states->toArray());


### PR DESCRIPTION
One downside to the package I can see is the fact that the package always scans the folder for state classes to auto-register them. I'd like to be able to opt-out of that behaviour!

This PR adds the config option to skip auto registering states, by adding a new config option that is turned off by default in order to keep backward compatibility