### PR TITLE
Feature/Allow to set custom StateChanged event

### DIFF
--- a/docs/working-with-states/01-configuring-states.md
+++ b/docs/working-with-states/01-configuring-states.md
@@ -111,6 +111,27 @@ abstract class PaymentState extends State
 }
 ```
 
+### Registering custom StateChanged event
+By default, when a state is changed, the `StateChanged` event is fired. If you want to use a custom event, you can register it in the `config` method:
+
+```php
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\StateConfig;
+
+use Your\Concrete\State\Event\CustomStateChanged;
+
+abstract class PaymentState extends State
+{
+    abstract public function color(): string;
+    
+    public static function config(): StateConfig
+    {
+        return parent::config()
+            ->stateChangedEvent(CustomStateChanged::class)
+        ;
+    }
+}
+```
 ## Configuring states using attributes
 
 If you're using PHP 8 or higher, you can also configure your state using attributes:

--- a/src/StateConfig.php
+++ b/src/StateConfig.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\ModelStates;
 
+use Spatie\ModelStates\Events\StateChanged;
 use Spatie\ModelStates\Exceptions\InvalidConfig;
 
 class StateConfig
@@ -17,6 +18,8 @@ class StateConfig
 
     /** @var string[] */
     public array $registeredStates = [];
+
+    public string $stateChangedEvent = StateChanged::class;
 
     public function __construct(
         string $baseStateClass
@@ -113,6 +116,13 @@ class StateConfig
         }
 
         $this->registeredStates[] = $stateClass;
+
+        return $this;
+    }
+
+    public function stateChangedEvent(string $event): StateConfig
+    {
+        $this->stateChangedEvent = $event;
 
         return $this;
     }

--- a/tests/Dummy/CustomEventModelState/CustomEventModelState.php
+++ b/tests/Dummy/CustomEventModelState/CustomEventModelState.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\CustomEventModelState;
+
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\StateConfig;
+
+abstract class CustomEventModelState extends State
+{
+    public static function config(): StateConfig
+    {
+        return parent::config()
+            ->default(CustomEventModelStateA::class)
+            ->allowTransition(CustomEventModelStateA::class, CustomEventModelStateB::class)
+            ->stateChangedEvent(CustomStateChangedEvent::class);
+    }
+}

--- a/tests/Dummy/CustomEventModelState/CustomEventModelStateA.php
+++ b/tests/Dummy/CustomEventModelState/CustomEventModelStateA.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\CustomEventModelState;
+
+class CustomEventModelStateA extends CustomEventModelState
+{
+
+}

--- a/tests/Dummy/CustomEventModelState/CustomEventModelStateB.php
+++ b/tests/Dummy/CustomEventModelState/CustomEventModelStateB.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\CustomEventModelState;
+
+class CustomEventModelStateB extends CustomEventModelState
+{
+
+}

--- a/tests/Dummy/CustomEventModelState/CustomInvalidEventModelState.php
+++ b/tests/Dummy/CustomEventModelState/CustomInvalidEventModelState.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\CustomEventModelState;
+
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\StateConfig;
+
+abstract class CustomInvalidEventModelState extends State
+{
+    public static function config(): StateConfig
+    {
+        return parent::config()
+            ->default(CustomInvalidEventModelStateA::class)
+            ->allowTransition(CustomInvalidEventModelStateA::class, CustomInvalidEventModelStateB::class)
+            ->stateChangedEvent(CustomInvalidStateChangedEvent::class);
+    }
+}

--- a/tests/Dummy/CustomEventModelState/CustomInvalidEventModelStateA.php
+++ b/tests/Dummy/CustomEventModelState/CustomInvalidEventModelStateA.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\CustomEventModelState;
+
+class CustomInvalidEventModelStateA extends CustomInvalidEventModelState
+{
+
+}

--- a/tests/Dummy/CustomEventModelState/CustomInvalidEventModelStateB.php
+++ b/tests/Dummy/CustomEventModelState/CustomInvalidEventModelStateB.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\CustomEventModelState;
+
+class CustomInvalidEventModelStateB extends CustomInvalidEventModelState
+{
+
+}

--- a/tests/Dummy/CustomEventModelState/CustomInvalidStateChangedEvent.php
+++ b/tests/Dummy/CustomEventModelState/CustomInvalidStateChangedEvent.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\CustomEventModelState;
+
+use Spatie\ModelStates\Events\StateChanged;
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\Transition;
+
+class CustomInvalidStateChangedEvent
+{
+
+}

--- a/tests/Dummy/CustomEventModelState/CustomStateChangedEvent.php
+++ b/tests/Dummy/CustomEventModelState/CustomStateChangedEvent.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\CustomEventModelState;
+
+use Spatie\ModelStates\Events\StateChanged;
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\Transition;
+
+class CustomStateChangedEvent extends StateChanged
+{
+
+}

--- a/tests/Dummy/TestModelCustomEvent.php
+++ b/tests/Dummy/TestModelCustomEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\ModelStates\HasStates;
+use Spatie\ModelStates\Tests\Dummy\CustomEventModelState\CustomEventModelState;
+use Spatie\ModelStates\Tests\Dummy\ModelStates\ModelState;
+
+class TestModelCustomEvent extends TestModel
+{
+    protected $casts = [
+        'state' => CustomEventModelState::class,
+    ];
+}

--- a/tests/Dummy/TestModelCustomInvalidEvent.php
+++ b/tests/Dummy/TestModelCustomInvalidEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\ModelStates\HasStates;
+use Spatie\ModelStates\Tests\Dummy\CustomEventModelState\CustomEventModelState;
+use Spatie\ModelStates\Tests\Dummy\CustomEventModelState\CustomInvalidEventModelState;
+use Spatie\ModelStates\Tests\Dummy\ModelStates\ModelState;
+
+class TestModelCustomInvalidEvent extends TestModel
+{
+    protected $casts = [
+        'state' => CustomInvalidEventModelState::class,
+    ];
+}

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -1,6 +1,12 @@
 <?php
 
 use Illuminate\Support\Facades\Event;
+use Spatie\ModelStates\Events\StateChanged;
+use Spatie\ModelStates\Exceptions\ClassDoesNotExtendBaseClass;
+use Spatie\ModelStates\Tests\Dummy\CustomEventModelState\CustomEventModelStateB;
+use Spatie\ModelStates\Tests\Dummy\CustomEventModelState\CustomInvalidEventModelStateB;
+use Spatie\ModelStates\Tests\Dummy\CustomEventModelState\CustomInvalidStateChangedEvent;
+use Spatie\ModelStates\Tests\Dummy\CustomEventModelState\CustomStateChangedEvent;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\ModelState;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateA;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateB;
@@ -13,6 +19,8 @@ use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateH;
 use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateX;
 use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateY;
 use Spatie\ModelStates\Tests\Dummy\TestModel;
+use Spatie\ModelStates\Tests\Dummy\TestModelCustomEvent;
+use Spatie\ModelStates\Tests\Dummy\TestModelCustomInvalidEvent;
 use Spatie\ModelStates\Tests\Dummy\TestModelUpdatingEvent;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithCustomTransition;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithDefault;
@@ -207,4 +215,35 @@ it('can override default transition', function () {
     TestModel::create()->state->transitionTo(StateB::class);
 
     Event::assertNotDispatched(TestModelUpdatingEvent::class);
+});
+
+it('can emit a custom state changed event', function () {
+    Event::fake();
+
+    $model = TestModelCustomEvent::create();
+
+    $model->state->transitionTo(CustomEventModelStateB::class);
+
+    Event::assertDispatched(CustomStateChangedEvent::class);
+});
+
+it('emits the standard state changed event', function () {
+    Event::fake();
+
+    $model = TestModel::create();
+
+    $model->state->transitionTo(StateB::class);
+
+    Event::assertDispatched(StateChanged::class);
+});
+
+it('should throw exception when custom state changed event does not extend StateChanged', function () {
+    Event::fake();
+
+    $model = TestModelCustomInvalidEvent::create();
+
+    $this->expectException(ClassDoesNotExtendBaseClass::class);
+    $this->expectExceptionMessage('Class ' . CustomInvalidStateChangedEvent::class . ' does not extend the `' . StateChanged::class . '` base class.');
+
+    $model->state->transitionTo(CustomInvalidEventModelStateB::class);
 });


### PR DESCRIPTION
This PR add the functionality of registering a custom `StateChanged` event. I stumbled upon this myself on a project for a client, where I wanted to listen to a specific state change and apply logic for this specific state. 

Since only the `StateChanged` event is fired, I have to add all the listeners to this event and then place if statements to check if the model is equal to the model I want the logic to apply to.

**Example**
In the event service provider I register `StateXChangedListener` to the `StateChanged` event. Right now I have to do this in the listener:
```php
if ($event->model::class === ModelWithStateX::class) {
   // Apply logic for StateX state change
}
```

Another way is to use the `updating` event on the model. But this is also not ideal as I don't know which state transition has taken place.

I also saw that there is an open discussion about custom events (see https://github.com/spatie/laravel-model-states/discussions/215). I am not sure if this is what they mean by customised state changed event, but for me this implementation would be very useful.