### PR TITLE
Feature/Method to allow all state transitions

### DIFF
--- a/docs/working-with-transitions/01-configuring-transitions.md
+++ b/docs/working-with-transitions/01-configuring-transitions.md
@@ -23,7 +23,22 @@ abstract class PaymentState extends State
 }
 ```
 
-In this example we're using both a simple transition, and a custom one. Transitions can be used like so:
+In this example we're using both a simple transition, and a custom one. You can also allow all transitions if your states are already properly registered:
+
+```php
+abstract class PaymentState extends State
+{
+    // …
+
+    public static function config(): StateConfig
+    {
+        return parent::config()
+            ->allowAllTransitions();
+    }
+}
+```
+
+Transitions can then be used like so:
 
 ```php
 $payment->state->transitionTo(Paid::class);

--- a/src/StateConfig.php
+++ b/src/StateConfig.php
@@ -117,6 +117,13 @@ class StateConfig
         return $this;
     }
 
+    public function allowAllTransitions(): StateConfig
+    {
+        $this->allowTransitions(collect($this->registeredStates)->crossJoin($this->registeredStates)->toArray());
+
+        return $this;
+    }
+
     /**
      * @param string|\Spatie\ModelStates\State $from
      * @param string|\Spatie\ModelStates\State $to

--- a/src/StateConfig.php
+++ b/src/StateConfig.php
@@ -117,8 +117,15 @@ class StateConfig
         return $this;
     }
 
+    /**
+     * @throws InvalidConfig
+     */
     public function allowAllTransitions(): StateConfig
     {
+        if (empty($this->registeredStates)) {
+            throw new InvalidConfig('No states registered for ' . $this->baseStateClass);
+        }
+
         $this->allowTransitions(collect($this->registeredStates)->crossJoin($this->registeredStates)->toArray());
 
         return $this;

--- a/tests/Dummy/AllowAllTransitionsState/AllowAllTransitionsState.php
+++ b/tests/Dummy/AllowAllTransitionsState/AllowAllTransitionsState.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState;
+
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\StateConfig;
+
+abstract class AllowAllTransitionsState extends State
+{
+    public static function config(): StateConfig
+    {
+        return parent::config()
+            ->default(StateA::class)
+            ->registerState(StateA::class)
+            ->registerState(StateB::class)
+            ->registerState(StateC::class)
+            ->allowAllTransitions();
+    }
+}

--- a/tests/Dummy/AllowAllTransitionsState/StateA.php
+++ b/tests/Dummy/AllowAllTransitionsState/StateA.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState;
+
+class StateA extends AllowAllTransitionsState
+{
+
+}

--- a/tests/Dummy/AllowAllTransitionsState/StateB.php
+++ b/tests/Dummy/AllowAllTransitionsState/StateB.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState;
+
+use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\AllowAllTransitionsState;
+
+class StateB extends AllowAllTransitionsState
+{
+
+}

--- a/tests/Dummy/AllowAllTransitionsState/StateC.php
+++ b/tests/Dummy/AllowAllTransitionsState/StateC.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState;
+
+use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\AllowAllTransitionsState;
+
+class StateC extends AllowAllTransitionsState
+{
+
+}

--- a/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/AllowAllTransitionsStateWithNoRegisteredStates.php
+++ b/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/AllowAllTransitionsStateWithNoRegisteredStates.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithNoRegisteredStates;
+
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\StateConfig;
+
+abstract class AllowAllTransitionsStateWithNoRegisteredStates extends State
+{
+    public static function config(): StateConfig
+    {
+        return parent::config()
+            ->default(StateAWithNoRegisteredStates::class)
+            ->allowAllTransitions();
+    }
+}

--- a/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/StateAWithNoRegisteredStates.php
+++ b/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/StateAWithNoRegisteredStates.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithNoRegisteredStates;
+
+class StateAWithNoRegisteredStates extends AllowAllTransitionsStateWithNoRegisteredStates
+{
+
+}

--- a/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/StateBWithNoRegisteredStates.php
+++ b/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/StateBWithNoRegisteredStates.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithNoRegisteredStates;
+
+class StateBWithNoRegisteredStates extends AllowAllTransitionsStateWithNoRegisteredStates
+{
+
+}

--- a/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/StateCWithNoRegisteredStates.php
+++ b/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/StateCWithNoRegisteredStates.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithNoRegisteredStates;
+
+class StateCWithNoRegisteredStates extends AllowAllTransitionsStateWithNoRegisteredStates
+{
+
+}

--- a/tests/Dummy/TestModelAllowAllTransitions.php
+++ b/tests/Dummy/TestModelAllowAllTransitions.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy;
+
+use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\AllowAllTransitionsState;
+
+class TestModelAllowAllTransitions extends TestModel
+{
+    protected $casts = [
+        'state' => AllowAllTransitionsState::class,
+    ];
+}

--- a/tests/Dummy/TestModelAllowAllTransitionsWithNoRegisteredStates.php
+++ b/tests/Dummy/TestModelAllowAllTransitionsWithNoRegisteredStates.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy;
+
+use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithNoRegisteredStates\AllowAllTransitionsStateWithNoRegisteredStates;
+
+class TestModelAllowAllTransitionsWithNoRegisteredStates extends TestModel
+{
+    protected $casts = [
+        'state' => AllowAllTransitionsStateWithNoRegisteredStates::class,
+    ];
+}

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -13,6 +13,7 @@ use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateH;
 use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateX;
 use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateY;
 use Spatie\ModelStates\Tests\Dummy\TestModel;
+use Spatie\ModelStates\Tests\Dummy\TestModelAllowAllTransitions;
 use Spatie\ModelStates\Tests\Dummy\TestModelUpdatingEvent;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithCustomTransition;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithDefault;
@@ -207,4 +208,25 @@ it('can override default transition', function () {
     TestModel::create()->state->transitionTo(StateB::class);
 
     Event::assertNotDispatched(TestModelUpdatingEvent::class);
+});
+
+it('should allow all transitions', function () {
+    $model = TestModelAllowAllTransitions::create();
+
+    expect($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateA::class))->toBeTrue()
+        ->and($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateB::class))->toBeTrue()
+        ->and($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateC::class))->toBeTrue();
+
+    $model->state->transitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateB::class);
+
+    expect($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateA::class))->toBeTrue()
+        ->and($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateB::class))->toBeTrue()
+        ->and($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateC::class))->toBeTrue();
+
+    $model->state->transitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateC::class);
+
+    expect($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateA::class))->toBeTrue()
+        ->and($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateB::class))->toBeTrue()
+        ->and($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateC::class))->toBeTrue();
+
 });

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Event;
+use Spatie\ModelStates\Exceptions\InvalidConfig;
+use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithNoRegisteredStates\AllowAllTransitionsStateWithNoRegisteredStates;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\ModelState;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateA;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateB;
@@ -14,6 +16,7 @@ use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateX;
 use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateY;
 use Spatie\ModelStates\Tests\Dummy\TestModel;
 use Spatie\ModelStates\Tests\Dummy\TestModelAllowAllTransitions;
+use Spatie\ModelStates\Tests\Dummy\TestModelAllowAllTransitionsWithNoRegisteredStates;
 use Spatie\ModelStates\Tests\Dummy\TestModelUpdatingEvent;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithCustomTransition;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithDefault;
@@ -229,4 +232,11 @@ it('should allow all transitions', function () {
         ->and($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateB::class))->toBeTrue()
         ->and($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateC::class))->toBeTrue();
 
+});
+
+it('should throw exception when allowing all transitions when there are no registered states', function () {
+    $this->expectException(InvalidConfig::class);
+    $this->expectExceptionMessage('No states registered for ' . AllowAllTransitionsStateWithNoRegisteredStates::class);
+
+    TestModelAllowAllTransitionsWithNoRegisteredStates::create();
 });


### PR DESCRIPTION
This PR adds a method to `StateConfig` to allow all state transitions, like so:

```php
public static function config(): StateConfig
{
    return parent::config()
        ->allowAllTransitions();
}
```

I stumbled upon this myself and saw that there was a discussion about this too (https://github.com/spatie/laravel-model-states/discussions/156).