### PR TITLE
Implement SerializesCastableAttributes in StateCaster

### DIFF
--- a/src/StateCaster.php
+++ b/src/StateCaster.php
@@ -3,10 +3,12 @@
 namespace Spatie\ModelStates;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Spatie\ModelStates\Exceptions\UnknownState;
 
-class StateCaster implements CastsAttributes
+class StateCaster implements CastsAttributes, SerializesCastableAttributes
 {
     /** @var string|\Spatie\ModelStates\State */
     private string $baseStateClass;
@@ -68,6 +70,11 @@ class StateCaster implements CastsAttributes
         }
 
         return $value::getMorphClass();
+    }
+
+    public function serialize(Model $model, string $key, mixed $value, array $attributes)
+    {
+        return $value instanceof State ? $value->getValue() : $value;
     }
 
     private function getStateMapping(): Collection

--- a/tests/StateCastingTest.php
+++ b/tests/StateCastingTest.php
@@ -136,3 +136,9 @@ it('field is always populated when set', function () {
 
     expect($model->state->getField())->toEqual('state');
 });
+
+it('serializes to a value', function() {
+    $model = new TestModel();
+
+    expect($model->toArray()['state'])->toBe(StateA::class);
+});


### PR DESCRIPTION
Currently, calling `toArray` on models will not serialize model states to their underlying values. This doesn't seem like correct behavior, as Laravel tries to serialize all objects to their primitive values whenever possible (for example `Carbon/DateTime` -> `string`).

This PR implements `SerializesCastableAttributes` in `StateCaster` to support this serialization.