### PR TITLE
Use jsonSerialize in StateCaster

### DIFF
--- a/src/StateCaster.php
+++ b/src/StateCaster.php
@@ -81,7 +81,7 @@ class StateCaster implements CastsAttributes, SerializesCastableAttributes
      */
     public function serialize($model, string $key, $value, array $attributes)
     {
-        return $value instanceof State ? $value->getValue() : $value;
+        return $value instanceof State ? $value->jsonSerialize() : $value;
     }
 
     private function getStateMapping(): Collection

--- a/tests/Dummy/ModelStates/StateB.php
+++ b/tests/Dummy/ModelStates/StateB.php
@@ -4,4 +4,8 @@ namespace Spatie\ModelStates\Tests\Dummy\ModelStates;
 
 class StateB extends ModelState
 {
+    public function jsonSerialize()
+    {
+        return ['name' => 'StateB'];
+    }
 }

--- a/tests/StateCastingTest.php
+++ b/tests/StateCastingTest.php
@@ -137,8 +137,16 @@ it('field is always populated when set', function () {
     expect($model->state->getField())->toEqual('state');
 });
 
-it('serializes to a value', function() {
+it('serializes to a value when calling toArray', function() {
     $model = new TestModel();
 
     expect($model->toArray()['state'])->toBe(StateA::class);
+});
+
+it('respects jsonSerialize in state classes', function() {
+    $model = new TestModel([
+        'state' => StateB::class,
+    ]);
+
+    expect($model->toJson())->toBe('{"state":{"name":"StateB"}}');
 });


### PR DESCRIPTION
#251 introduced an issue where if someone has overridden `jsonSerialize` in their state classes, it would become ignored when serializing models to JSON.

This solves the issue by instead using `jsonSerialize` in the `StateCaster`.


