### PR TITLE
Fix missing namespace in phpdoc

### DIFF
--- a/src/Exceptions/CouldNotPerformTransition.php
+++ b/src/Exceptions/CouldNotPerformTransition.php
@@ -8,7 +8,7 @@ class CouldNotPerformTransition extends Exception
 {
     /**
      * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @param  Transition  $transitionClass
+     * @param  \Spatie\ModelStates\Transition  $transitionClass
      * @return  CouldNotPerformTransition
      */
     public static function notAllowed($model, $transitionClass): CouldNotPerformTransition


### PR DESCRIPTION
Previously the Transition typehint in the phpdoc was not fully qualified and so IDE's and static analysers complained that the function expects a Class of type \Spatie\ModelStates\Exception\Transition