### PR TITLE
fix(config): var annotation for `$allowedTransitions`

### DIFF
--- a/src/StateConfig.php
+++ b/src/StateConfig.php
@@ -13,7 +13,7 @@ class StateConfig
     /** @var string|null|\Spatie\ModelStates\State */
     public ?string $defaultStateClass = null;
 
-    /** @var string[] */
+    /** @var array<string, null|class-string<\Spatie\ModelStates\Transition>> */
     public array $allowedTransitions = [];
 
     /** @var string[] */


### PR DESCRIPTION
All `$allowedTransitions` strings must be a class string which extends the abstract `Transition` class.