### PR TITLE
Make using allowAllTransitions() less cumbersome

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "illuminate/contracts": "^8.73 | ^9.0 | ^10.0 | ^11.0",
         "illuminate/database": "^8.73 | ^9.0 | ^10.0 | ^11.0",
         "illuminate/support": "^8.73 | ^9.0 | ^10.0 | ^11.0",
-        "spatie/laravel-package-tools": "^1.9"
+        "spatie/laravel-package-tools": "^1.9",
+        "spatie/php-structure-discoverer": "^2.2"
     },
     "require-dev": {
         "orchestra/testbench": "^6.23 | ^7.0 | ^8.0 | ^9.0",

--- a/docs/working-with-transitions/01-configuring-transitions.md
+++ b/docs/working-with-transitions/01-configuring-transitions.md
@@ -23,7 +23,7 @@ abstract class PaymentState extends State
 }
 ```
 
-In this example we're using both a simple transition, and a custom one. You can also allow all transitions if your states are already properly registered:
+In this example we're using both a simple transition, and a custom one. You can also allow all transitions for all registered states. Concrete states extending the abstract state class that are located in the same directory as the abstract state class will be automatically registered:
 
 ```php
 abstract class PaymentState extends State

--- a/tests/Dummy/AllowAllTransitionsState/AllowAllTransitionsState.php
+++ b/tests/Dummy/AllowAllTransitionsState/AllowAllTransitionsState.php
@@ -11,9 +11,6 @@ abstract class AllowAllTransitionsState extends State
     {
         return parent::config()
             ->default(StateA::class)
-            ->registerState(StateA::class)
-            ->registerState(StateB::class)
-            ->registerState(StateC::class)
             ->allowAllTransitions();
     }
 }

--- a/tests/Dummy/AllowAllTransitionsStateWithExplicitlyRegisteredStates/AllowAllTransitionsStateWithExplicitlyRegisteredStates.php
+++ b/tests/Dummy/AllowAllTransitionsStateWithExplicitlyRegisteredStates/AllowAllTransitionsStateWithExplicitlyRegisteredStates.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithExplicitlyRegisteredStates;
+
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\StateConfig;
+use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithNoRegisteredStates\StateAWithNoRegisteredStates;
+use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithNoRegisteredStates\StateBWithNoRegisteredStates;
+use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithNoRegisteredStates\StateCWithNoRegisteredStates;
+
+abstract class AllowAllTransitionsStateWithExplicitlyRegisteredStates extends State
+{
+    public static function config(): StateConfig
+    {
+        return parent::config()
+            ->registerState(StateAWithNoRegisteredStates::class)
+            ->registerState(StateBWithNoRegisteredStates::class)
+            ->registerState(StateCWithNoRegisteredStates::class)
+            ->default(StateAWithNoRegisteredStates::class)
+            ->allowAllTransitions();
+    }
+}

--- a/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/AllowAllTransitionsStateWithNoRegisteredStates.php
+++ b/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/AllowAllTransitionsStateWithNoRegisteredStates.php
@@ -4,13 +4,14 @@ namespace Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithNoRegistere
 
 use Spatie\ModelStates\State;
 use Spatie\ModelStates\StateConfig;
+use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateA;
 
 abstract class AllowAllTransitionsStateWithNoRegisteredStates extends State
 {
     public static function config(): StateConfig
     {
         return parent::config()
-            ->default(StateAWithNoRegisteredStates::class)
+            ->default(StateA::class)
             ->allowAllTransitions();
     }
 }

--- a/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/StateAWithNoRegisteredStates.php
+++ b/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/StateAWithNoRegisteredStates.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithNoRegisteredStates;
 
-class StateAWithNoRegisteredStates extends AllowAllTransitionsStateWithNoRegisteredStates
+use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithExplicitlyRegisteredStates\AllowAllTransitionsStateWithExplicitlyRegisteredStates;
+
+class StateAWithNoRegisteredStates extends AllowAllTransitionsStateWithExplicitlyRegisteredStates
 {
 
 }

--- a/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/StateBWithNoRegisteredStates.php
+++ b/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/StateBWithNoRegisteredStates.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithNoRegisteredStates;
 
-class StateBWithNoRegisteredStates extends AllowAllTransitionsStateWithNoRegisteredStates
+use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithExplicitlyRegisteredStates\AllowAllTransitionsStateWithExplicitlyRegisteredStates;
+
+class StateBWithNoRegisteredStates extends AllowAllTransitionsStateWithExplicitlyRegisteredStates
 {
 
 }

--- a/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/StateCWithNoRegisteredStates.php
+++ b/tests/Dummy/AllowAllTransitionsStateWithNoRegisteredStates/StateCWithNoRegisteredStates.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithNoRegisteredStates;
 
-class StateCWithNoRegisteredStates extends AllowAllTransitionsStateWithNoRegisteredStates
+use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithExplicitlyRegisteredStates\AllowAllTransitionsStateWithExplicitlyRegisteredStates;
+
+class StateCWithNoRegisteredStates extends AllowAllTransitionsStateWithExplicitlyRegisteredStates
 {
 
 }

--- a/tests/Dummy/TestModelAllowAllTransitionsWithExplicitlyRegisteredStates.php
+++ b/tests/Dummy/TestModelAllowAllTransitionsWithExplicitlyRegisteredStates.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy;
+
+use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithExplicitlyRegisteredStates\AllowAllTransitionsStateWithExplicitlyRegisteredStates;
+
+class TestModelAllowAllTransitionsWithExplicitlyRegisteredStates extends TestModel
+{
+    protected $casts = [
+        'state' => AllowAllTransitionsStateWithExplicitlyRegisteredStates::class,
+    ];
+}

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Event;
 use Spatie\ModelStates\Exceptions\InvalidConfig;
-use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithNoRegisteredStates\AllowAllTransitionsStateWithNoRegisteredStates;
+use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsStateWithNoRegisteredStates;
 use Spatie\ModelStates\Events\StateChanged;
 use Spatie\ModelStates\Exceptions\ClassDoesNotExtendBaseClass;
 use Spatie\ModelStates\Tests\Dummy\CustomEventModelState\CustomEventModelStateB;
@@ -22,12 +22,14 @@ use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateX;
 use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateY;
 use Spatie\ModelStates\Tests\Dummy\TestModel;
 use Spatie\ModelStates\Tests\Dummy\TestModelAllowAllTransitions;
+use Spatie\ModelStates\Tests\Dummy\TestModelAllowAllTransitionsWithExplicitlyRegisteredStates;
 use Spatie\ModelStates\Tests\Dummy\TestModelAllowAllTransitionsWithNoRegisteredStates;
 use Spatie\ModelStates\Tests\Dummy\TestModelCustomEvent;
 use Spatie\ModelStates\Tests\Dummy\TestModelCustomInvalidEvent;
 use Spatie\ModelStates\Tests\Dummy\TestModelUpdatingEvent;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithCustomTransition;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithDefault;
+use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState;
 
 it('resolve state class', function () {
     expect(ModelState::resolveStateClass(StateA::class))->toEqual(StateA::class);
@@ -255,27 +257,52 @@ it('should throw exception when custom state changed event does not extend State
 it('should allow all transitions', function () {
     $model = TestModelAllowAllTransitions::create();
 
-    expect($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateA::class))->toBeTrue()
-        ->and($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateB::class))->toBeTrue()
-        ->and($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateC::class))->toBeTrue();
+    expect($model->state)
+        ->canTransitionTo(AllowAllTransitionsState\StateA::class)->toBeTrue()
+        ->canTransitionTo(AllowAllTransitionsState\StateB::class)->toBeTrue()
+        ->canTransitionTo(AllowAllTransitionsState\StateC::class)->toBeTrue();
 
-    $model->state->transitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateB::class);
+    $model->state->transitionTo(AllowAllTransitionsState\StateB::class);
 
-    expect($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateA::class))->toBeTrue()
-        ->and($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateB::class))->toBeTrue()
-        ->and($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateC::class))->toBeTrue();
+    expect($model->state)
+        ->canTransitionTo(AllowAllTransitionsState\StateA::class)->toBeTrue()
+        ->canTransitionTo(AllowAllTransitionsState\StateB::class)->toBeTrue()
+        ->canTransitionTo(AllowAllTransitionsState\StateC::class)->toBeTrue();
 
-    $model->state->transitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateC::class);
+    $model->state->transitionTo(AllowAllTransitionsState\StateC::class);
 
-    expect($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateA::class))->toBeTrue()
-        ->and($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateB::class))->toBeTrue()
-        ->and($model->state->canTransitionTo(\Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState\StateC::class))->toBeTrue();
+    expect($model->state)
+        ->canTransitionTo(AllowAllTransitionsState\StateA::class)->toBeTrue()
+        ->canTransitionTo(AllowAllTransitionsState\StateB::class)->toBeTrue()
+        ->canTransitionTo(AllowAllTransitionsState\StateC::class)->toBeTrue();
+});
 
+it('should allow all transitions for explicitly registered states', function () {
+    $model = TestModelAllowAllTransitionsWithExplicitlyRegisteredStates::create();
+
+    expect($model->state)
+        ->canTransitionTo(AllowAllTransitionsStateWithNoRegisteredStates\StateAWithNoRegisteredStates::class)->toBeTrue()
+        ->canTransitionTo(AllowAllTransitionsStateWithNoRegisteredStates\StateBWithNoRegisteredStates::class)->toBeTrue()
+        ->canTransitionTo(AllowAllTransitionsStateWithNoRegisteredStates\StateCWithNoRegisteredStates::class)->toBeTrue();
+
+    $model->state->transitionTo(AllowAllTransitionsStateWithNoRegisteredStates\StateBWithNoRegisteredStates::class);
+
+    expect($model->state)
+        ->canTransitionTo(AllowAllTransitionsStateWithNoRegisteredStates\StateAWithNoRegisteredStates::class)->toBeTrue()
+        ->canTransitionTo(AllowAllTransitionsStateWithNoRegisteredStates\StateBWithNoRegisteredStates::class)->toBeTrue()
+        ->canTransitionTo(AllowAllTransitionsStateWithNoRegisteredStates\StateCWithNoRegisteredStates::class)->toBeTrue();
+
+    $model->state->transitionTo(AllowAllTransitionsStateWithNoRegisteredStates\StateCWithNoRegisteredStates::class);
+
+    expect($model->state)
+        ->canTransitionTo(AllowAllTransitionsStateWithNoRegisteredStates\StateAWithNoRegisteredStates::class)->toBeTrue()
+        ->canTransitionTo(AllowAllTransitionsStateWithNoRegisteredStates\StateBWithNoRegisteredStates::class)->toBeTrue()
+        ->canTransitionTo(AllowAllTransitionsStateWithNoRegisteredStates\StateCWithNoRegisteredStates::class)->toBeTrue();
 });
 
 it('should throw exception when allowing all transitions when there are no registered states', function () {
     $this->expectException(InvalidConfig::class);
-    $this->expectExceptionMessage('No states registered for ' . AllowAllTransitionsStateWithNoRegisteredStates::class);
+    $this->expectExceptionMessage('No states registered for ' . AllowAllTransitionsStateWithNoRegisteredStates\AllowAllTransitionsStateWithNoRegisteredStates::class);
 
     TestModelAllowAllTransitionsWithNoRegisteredStates::create();
 });


### PR DESCRIPTION
One of the great things about this package is that it will automatically load states that are placed in the same directory as the abstract base state class. There is no need to manually register concrete states in the same directory...with one exception - the `allowAllTransitions()` config method.

Currently the docs show the following example:

```php
abstract class PaymentState extends State
{
    // …

    public static function config(): StateConfig
    {
        return parent::config()
            ->allowAllTransitions();
    }
}
```

However, this code is not possible to execute without it throwing a Spatie\ModelStates\Exceptions\InvalidConfig exception.

My pull request updates the `allowAllTransitions()` method  to automatically register the concrete state classes in the same directory as the abstract base state class, thereby making the above code work as a user might expect. 

This eliminates the cumbersome overhead of explicitly registering every state in the same directory when using `allowAlltransitions()`. 