### PR TITLE
Add ability to ignore transition to same state

### DIFF
--- a/docs/working-with-transitions/01-configuring-transitions.md
+++ b/docs/working-with-transitions/01-configuring-transitions.md
@@ -44,7 +44,37 @@ Transitions can then be used like so:
 $payment->state->transitionTo(Paid::class);
 ```
 
-This line will only work when a valid transition was configured. If the initial state of `$payment` already was `Paid`, a `\Spatie\ModelStates\Exceptions\TransitionNotFound` will be thrown instead of changing the state. 
+This line will only work when a valid transition was configured. If the initial state of `$payment` already was `Paid`, a `\Spatie\ModelStates\Exceptions\TransitionNotFound` will be thrown instead of changing the state.
+
+## Ignoring same state transitions
+
+In some cases you may want to handle transition to same state without manually setting `allowTransition`, you can call `ignoreSameState`
+
+Please note that the `StateChanged` event will fire anyway.
+
+```php
+abstract class PaymentState extends State
+{
+    // …
+
+    public static function config(): StateConfig
+    {
+        return parent::config()
+            ->ignoreSameState()
+            ->allowTransition([Created::class, Pending::class], Failed::class, ToFailed::class);
+    }
+}
+```
+
+It also works with `IgnoreSameState` Attribute
+
+```php
+#[IgnoreSameState]
+abstract class PaymentState extends State
+{
+    //...
+}
+```
 
 ## Allow multiple transitions at once
 

--- a/src/Attributes/AttributeLoader.php
+++ b/src/Attributes/AttributeLoader.php
@@ -35,6 +35,12 @@ class AttributeLoader
 
             $stateConfig->default($defaultStateAttribute->defaultStateClass);
         }
+
+        if ($this->reflectionClass->getAttributes(IgnoreSameState::class)[0] ?? null) {
+            /** @var \Spatie\ModelStates\Attributes\IgnoreSameState $transitionAttribute */
+
+            $stateConfig->ignoreSameState();
+        }
 	
 	    $registerStateAttributes = $this->reflectionClass->getAttributes(RegisterState::class);
 		

--- a/src/Attributes/IgnoreSameState.php
+++ b/src/Attributes/IgnoreSameState.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelStates\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class IgnoreSameState {}

--- a/src/StateConfig.php
+++ b/src/StateConfig.php
@@ -19,6 +19,9 @@ class StateConfig
     /** @var string[] */
     public array $registeredStates = [];
 
+    /** @var bool */
+    public bool $shouldIgnoreSameState = false;
+
     public string $stateChangedEvent = StateChanged::class;
 
     public function __construct(
@@ -30,6 +33,13 @@ class StateConfig
     public function default(string $defaultStateClass): StateConfig
     {
         $this->defaultStateClass = $defaultStateClass;
+
+        return $this;
+    }
+
+    public function ignoreSameState(): StateConfig
+    {
+        $this->shouldIgnoreSameState = true;
 
         return $this;
     }
@@ -72,6 +82,10 @@ class StateConfig
 
     public function isTransitionAllowed(string $fromMorphClass, string $toMorphClass): bool
     {
+        if($this->shouldIgnoreSameState && $fromMorphClass === $toMorphClass){
+            return true;
+        }
+
         $transitionKey = $this->createTransitionKey($fromMorphClass, $toMorphClass);
 
         return array_key_exists($transitionKey, $this->allowedTransitions);
@@ -79,6 +93,10 @@ class StateConfig
 
     public function resolveTransitionClass(string $fromMorphClass, string $toMorphClass): ?string
     {
+        if($this->shouldIgnoreSameState && $fromMorphClass === $toMorphClass) {
+            return null;
+        }
+
         $transitionKey = $this->createTransitionKey($fromMorphClass, $toMorphClass);
 
         return $this->allowedTransitions[$transitionKey];

--- a/src/StateConfig.php
+++ b/src/StateConfig.php
@@ -93,13 +93,13 @@ class StateConfig
 
     public function resolveTransitionClass(string $fromMorphClass, string $toMorphClass): ?string
     {
-        if($this->shouldIgnoreSameState && $fromMorphClass === $toMorphClass) {
-            return null;
-        }
-
         $transitionKey = $this->createTransitionKey($fromMorphClass, $toMorphClass);
 
-        return $this->allowedTransitions[$transitionKey];
+        if(array_key_exists($transitionKey, $this->allowedTransitions)) {
+            return $this->allowedTransitions[$transitionKey];
+        }
+
+        return null;
     }
 
     public function transitionableStates(string $fromMorphClass): array

--- a/tests/Dummy/IgnoreSameStateModelState/IgnoreSameStateModelAttributeState.php
+++ b/tests/Dummy/IgnoreSameStateModelState/IgnoreSameStateModelAttributeState.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\IgnoreSameStateModelState;
+
+use Spatie\ModelStates\Attributes\AllowTransition;
+use Spatie\ModelStates\Attributes\DefaultState;
+use Spatie\ModelStates\Attributes\IgnoreSameState;
+use Spatie\ModelStates\State;
+
+#[
+    DefaultState(IgnoreSameStateModelAttributeStateA::class),
+    AllowTransition(IgnoreSameStateModelAttributeStateA::class, IgnoreSameStateModelAttributeStateB::class),
+    IgnoreSameState
+]
+abstract class IgnoreSameStateModelAttributeState extends State
+{
+}

--- a/tests/Dummy/IgnoreSameStateModelState/IgnoreSameStateModelAttributeStateA.php
+++ b/tests/Dummy/IgnoreSameStateModelState/IgnoreSameStateModelAttributeStateA.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\IgnoreSameStateModelState;
+
+
+class IgnoreSameStateModelAttributeStateA extends IgnoreSameStateModelAttributeState
+{
+}

--- a/tests/Dummy/IgnoreSameStateModelState/IgnoreSameStateModelAttributeStateB.php
+++ b/tests/Dummy/IgnoreSameStateModelState/IgnoreSameStateModelAttributeStateB.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\IgnoreSameStateModelState;
+
+class IgnoreSameStateModelAttributeStateB extends IgnoreSameStateModelAttributeState
+{
+}

--- a/tests/Dummy/IgnoreSameStateModelState/IgnoreSameStateModelState.php
+++ b/tests/Dummy/IgnoreSameStateModelState/IgnoreSameStateModelState.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\IgnoreSameStateModelState;
+
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\StateConfig;
+
+abstract class IgnoreSameStateModelState extends State
+{
+    public static function config(): StateConfig
+    {
+        return parent::config()
+            ->ignoreSameState()
+            ->allowTransition(IgnoreSameStateModelStateA::class, IgnoreSameStateModelStateB::class)
+            ->default(IgnoreSameStateModelStateA::class);
+    }
+}

--- a/tests/Dummy/IgnoreSameStateModelState/IgnoreSameStateModelStateA.php
+++ b/tests/Dummy/IgnoreSameStateModelState/IgnoreSameStateModelStateA.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\IgnoreSameStateModelState;
+
+class IgnoreSameStateModelStateA extends IgnoreSameStateModelState
+{
+}

--- a/tests/Dummy/IgnoreSameStateModelState/IgnoreSameStateModelStateB.php
+++ b/tests/Dummy/IgnoreSameStateModelState/IgnoreSameStateModelStateB.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\IgnoreSameStateModelState;
+
+class IgnoreSameStateModelStateB extends IgnoreSameStateModelState
+{
+}

--- a/tests/Dummy/TestModelIgnoresSameState.php
+++ b/tests/Dummy/TestModelIgnoresSameState.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy;
+
+use Spatie\ModelStates\Tests\Dummy\IgnoreSameStateModelState\IgnoreSameStateModelState;
+
+class TestModelIgnoresSameState extends TestModel
+{
+    protected $casts = [
+        'state' => IgnoreSameStateModelState::class,
+    ];
+}

--- a/tests/Dummy/TestModelIgnoresSameStateByAttribute.php
+++ b/tests/Dummy/TestModelIgnoresSameStateByAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy;
+
+use Spatie\ModelStates\Tests\Dummy\IgnoreSameStateModelState\IgnoreSameStateModelAttributeState;
+
+class TestModelIgnoresSameStateByAttribute extends TestModel
+{
+    protected $casts = [
+        'state' => IgnoreSameStateModelAttributeState::class,
+    ];
+}

--- a/tests/TransitionTest.php
+++ b/tests/TransitionTest.php
@@ -1,10 +1,12 @@
 <?php
 
+use Spatie\ModelStates\Tests\Dummy\IgnoreSameStateModelState\IgnoreSameStateModelAttributeStateA;
 use Illuminate\Support\Facades\Event;
 use Spatie\ModelStates\DefaultTransition;
 use Spatie\ModelStates\Events\StateChanged;
 use Spatie\ModelStates\Exceptions\TransitionNotAllowed;
 use Spatie\ModelStates\Exceptions\TransitionNotFound;
+use Spatie\ModelStates\Tests\Dummy\IgnoreSameStateModelState\IgnoreSameStateModelStateA;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateA;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateB;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateC;
@@ -13,6 +15,8 @@ use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateX;
 use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateY;
 use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateZ;
 use Spatie\ModelStates\Tests\Dummy\TestModel;
+use Spatie\ModelStates\Tests\Dummy\TestModelIgnoresSameState;
+use Spatie\ModelStates\Tests\Dummy\TestModelIgnoresSameStateByAttribute;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithCustomTransition;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithTransitionsFromArray;
 use Spatie\ModelStates\Tests\Dummy\Transitions\CustomInvalidTransition;
@@ -170,4 +174,28 @@ it('can transition twice', function () {
     $model->refresh();
 
     expect($model->state)->toBeInstanceOf(StateC::class);
+});
+
+it('ignore transition to same state', function(){
+    $model = TestModelIgnoresSameState::create([
+        'state' => IgnoreSameStateModelStateA::class
+    ]);
+
+    expect($model->state->canTransitionTo(IgnoreSameStateModelStateA::class))->toBeTrue();
+
+    $model->state->transitionTo(IgnoreSameStateModelStateA::class);
+
+    expect($model->state)->toBeInstanceOf(IgnoreSameStateModelStateA::class);
+});
+
+it('ignore transition to same state using Attribute', function(){
+    $model = TestModelIgnoresSameStateByAttribute::create([
+        'state' => IgnoreSameStateModelAttributeStateA::class
+    ]);
+
+    expect($model->state->canTransitionTo(IgnoreSameStateModelAttributeStateA::class))->toBeTrue();
+
+    $model->state->transitionTo(IgnoreSameStateModelAttributeStateA::class);
+
+    expect($model->state)->toBeInstanceOf(IgnoreSameStateModelAttributeStateA::class);
 });


### PR DESCRIPTION
In some cases it is convenient not to get an error when you try to perform a transition to the same state, for example, when the state comes from the API and you do not know in advance what it is, so as not to manually register such cases through allowTransition, I added the ability to ignore such transitions