### PR TITLE
Feature: Added ...transitionArgs to default transition constructor call to allow arguments use for custom default transition

### DIFF
--- a/docs/working-with-transitions/06-custom-default-transition-class.md
+++ b/docs/working-with-transitions/06-custom-default-transition-class.md
@@ -1,0 +1,78 @@
+---
+title: Custom default transition class
+weight: 6
+---
+
+When working with state transitions, you may need to pass additional contextual data to your `StateChanged` event
+listeners. While custom transitions allow this for specific state changes, sometimes you need this functionality for all
+transitions. To handle such scenarios `DefaultTransition` class can be extended.
+
+The following example uses different logic depending on how `transitionTo` is called.
+
+Creating custom default transition class:
+
+```php
+use Spatie\ModelStates\DefaultTransition;
+use Spatie\ModelStates\State;
+
+class CustomDefaultTransitionWithAttributes extends DefaultTransition
+{
+    public function __construct($model, string $field, State $newState, public bool $silent = false)
+    {
+        parent::__construct($model, $field, $newState);
+    }
+}
+```
+
+Register your custom transition class in `config/model-states.php`:
+
+```php
+return [
+    'default_transition' => CustomDefaultTransitionWithAttributes::class
+];
+```
+
+Implement your state change listener to use the custom parameter:
+
+```php
+use Spatie\ModelStates\Events\StateChanged;
+
+class OrderStateChangedListener
+{
+    public function handle(StateChanged $event): void
+    {
+        $isSilent = $event->transition->silent;
+
+        $this->processOrderState($event->model);
+
+        if (! $isSilent) {
+            $this->notifyUser($event->model);
+        }
+    }
+}
+```
+
+Now we can pass additional parameter to `transitionTo` method, to omit notification logic:
+
+```php
+class OrderService {
+    public function markAsPaid(Order $order): void
+    {
+        // Will trigger notification
+        $order->state->transitionTo(PaidState::class);
+        // Also can be specified explicitly
+        $order->state->transitionTo(PaidState::class, false);
+    }
+
+    public function markAsPaidSilently(Order $order): void
+    {
+        // Will not trigger notification
+        $order->state->transitionTo(PaidState::class, true);
+    }
+}
+```
+
+Important notes:
+
+- Custom parameters are only available within the context of the event listeners
+- Parameters must be serializable if you plan to queue your state change listeners

--- a/src/State.php
+++ b/src/State.php
@@ -292,7 +292,8 @@ abstract class State implements Castable, JsonSerializable
             $transition = new $defaultTransition(
                 $this->model,
                 $this->field,
-                $newState
+                $newState,
+                ...$transitionArgs
             );
         } else {
             $transition = new $transitionClass($this->model, ...$transitionArgs);

--- a/tests/Dummy/Transitions/CustomDefaultTransitionWithAttributes.php
+++ b/tests/Dummy/Transitions/CustomDefaultTransitionWithAttributes.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\Transitions;
+
+use Spatie\ModelStates\DefaultTransition;
+use Spatie\ModelStates\State;
+
+class CustomDefaultTransitionWithAttributes extends DefaultTransition
+{
+    public function __construct($model, string $field, State $newState, public bool $silent = false)
+    {
+        parent::__construct($model, $field, $newState);
+    }
+}

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -223,6 +223,24 @@ it('can override default transition', function () {
     Event::assertNotDispatched(TestModelUpdatingEvent::class);
 });
 
+it('can use attributes with custom default transition', function () {
+    Event::fake();
+    $customDefaultTransitionClass = \Spatie\ModelStates\Tests\Dummy\Transitions\CustomDefaultTransitionWithAttributes::class;
+
+    config()->set('model-states.default_transition', $customDefaultTransitionClass);
+
+    TestModel::create()->state->transitionTo(StateB::class, true);
+
+    Event::assertDispatched(
+        StateChanged::class,
+        function (StateChanged $event) use ($customDefaultTransitionClass) {
+            $transition = $event->transition;
+            return $transition instanceof $customDefaultTransitionClass
+                && $transition->silent === true;
+        }
+    );
+});
+
 it('can emit a custom state changed event', function () {
     Event::fake();
 


### PR DESCRIPTION
### Foreword
Custom Transition can be initialized with arguments from transitionTo parameters. 
Custom **default** Transition can be registeren in the configuration for transitions between all states, but can not be initialized with arguments as **non default** transition.

### Requirement
When calling `transitionTo` method I would like to pass additional arguments that can be used in StateChanged event listener.

### Suggestion
Add `...transitionArgs` to `$defaultTransition(...)` constructor call.

### Use case
We need to handle status change in event listener, but depending on where `transitionTo` called from, in some cases we should notify user about event, but in some cases not. We can create custom DefaultTransition with additional silent parameter.

``` php
// CustomDefaultTransitionWithAttributes.php

class CustomDefaultTransitionWithAttributes extends DefaultTransition
{
    public function __construct($model, string $field, State $newState, public bool $silent = false)
    {
        parent::__construct($model, $field, $newState);
    }
}

// model-states.php

return [
    'default_transition' => CustomDefaultTransitionWithAttributes::class
];

// OrderStateChangedListener.php

class OrderStateChangedListener
{
    public function handle(StatusChange $event): void
    {
        // do some logic
        if (! $event->transition->silent) {
            // send notification
        }
    }
}

// Business logic layer

$order->status->transitionTo($status->value); // Sends notification

$order->status->transitionTo($status->value, false);  // Sends notification

$order->status->transitionTo($status->value, true); // Doesn't send notification, but still performs logic
```