### PR TITLE
Contract / Interface for Models that use `HasStates` trait.

### DIFF
--- a/docs/working-with-states/01-configuring-states.md
+++ b/docs/working-with-states/01-configuring-states.md
@@ -19,8 +19,6 @@ class Payment extends Model implements HasStatesContract
 }
 ```
 
-
-
 A model can have as many state fields as you want, and you're allowed to call them whatever you want. Just make sure every state has a corresponding database string field.
 
 ```php

--- a/docs/working-with-states/01-configuring-states.md
+++ b/docs/working-with-states/01-configuring-states.md
@@ -3,15 +3,12 @@ title: Configuring states
 weight: 1
 ---
 
-This package provides a `HasStates` trait which you can use in whatever model you want state support in. Within your codebase, each state is represented by a class, and will be serialised to the database by this package behind the scenes. For improved type-hinting, the package also provides a `HasStatesContract` interface.
-
-This way you don't have to worry about whether a state is in its textual form or not: you're always working with state objects.
+This package provides a `HasStates` trait which you can use in whatever model you want state support in. Within your codebase, each state is represented by a class, and will be serialised to the database by this package behind the scenes.
 
 ```php
 use Spatie\ModelStates\HasStates;
-use Spatie\ModelStates\HasStatesContract;
 
-class Payment extends Model implements HasStatesContract
+class Payment extends Model
 {
     use HasStates;
 
@@ -159,3 +156,21 @@ abstract class PaymentState extends State
 ```
 
 Next up, we'll take a moment to discuss how state classes are serialized to the database.
+
+## Improved typehinting
+
+Optionally, for improved type-hinting, the package also provides a `HasStatesContract` interface.
+
+This way you don't have to worry about whether a state is in its textual form or not: you're always working with state objects.
+
+```php
+use Spatie\ModelStates\HasStates;
+use Spatie\ModelStates\HasStatesContract;
+
+class Payment extends Model implements HasStatesContract
+{
+    use HasStates;
+
+    // …
+}
+```

--- a/docs/working-with-states/01-configuring-states.md
+++ b/docs/working-with-states/01-configuring-states.md
@@ -3,20 +3,23 @@ title: Configuring states
 weight: 1
 ---
 
-This package provides a `HasStates` trait which you can use in whatever model you want state support in. Within your codebase, each state is represented by a class, and will be serialised to the database by this package behind the scenes.
+This package provides a `HasStates` trait which you can use in whatever model you want state support in. Within your codebase, each state is represented by a class, and will be serialised to the database by this package behind the scenes. For improved type-hinting, the package also provides a `HasStatesContract` interface.
 
 This way you don't have to worry about whether a state is in its textual form or not: you're always working with state objects.
 
 ```php
 use Spatie\ModelStates\HasStates;
+use Spatie\ModelStates\HasStatesContract;
 
-class Payment extends Model
+class Payment extends Model implements HasStatesContract
 {
     use HasStates;
 
     // …
 }
 ```
+
+
 
 A model can have as many state fields as you want, and you're allowed to call them whatever you want. Just make sure every state has a corresponding database string field.
 

--- a/src/HasStatesContract.php
+++ b/src/HasStatesContract.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spatie\ModelStates;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+interface HasStatesContract
+{
+    public static function bootHasStates(): void;
+
+    public function initializeHasStates(): void;
+
+    public static function getStates(): Collection;
+
+    public static function getDefaultStates(): Collection;
+
+    public static function getDefaultStateFor(string $fieldName): ?string;
+
+    public static function getStatesFor(string $fieldName): Collection;
+
+    public function scopeWhereState(Builder $builder, string $column, $states): Builder;
+
+    public function scopeWhereNotState(Builder $builder, string $column, $states): Builder;
+
+    public function scopeOrWhereState(Builder $builder, string $column, $states): Builder;
+
+    public function scopeOrWhereNotState(Builder $builder, string $column, $states): Builder;
+}


### PR DESCRIPTION
Models using the `HasStates` trait currently can't be effectively Type Hinted when attempting to hook into external libraries.
This provided interface `HasStatesContract` will allow for type hinting of models that use States, as well as enforcement of the State functions.

This is something I ran into when building some integration with Filament, where you may have a custom re-usable Action / Form field that may not be tied to a specific model but is used for models with States.