### PR TITLE
fix(config): var annotation for `$baseStateClass` and `$defaultStateClass`

### DIFF
--- a/src/StateConfig.php
+++ b/src/StateConfig.php
@@ -9,10 +9,10 @@ use Spatie\StructureDiscoverer\Discover;
 
 class StateConfig
 {
-    /** @var string|\Spatie\ModelStates\State */
+    /** @var class-string<\Spatie\ModelStates\State<\Illuminate\Database\Eloquent\Model>> */
     public string $baseStateClass;
 
-    /** @var string|null|\Spatie\ModelStates\State */
+    /** @var class-string<\Spatie\ModelStates\State<\Illuminate\Database\Eloquent\Model>>|null */
     public ?string $defaultStateClass = null;
 
     /** @var array<string, null|class-string<\Spatie\ModelStates\Transition>> */


### PR DESCRIPTION
Both `$baseStateClass` and `$defaultStateClass` strings must be a class string which extends the abstract `State` class or `null`.