### PR TITLE
Feature: When a Custom Transition is/extends the Default Transition, give it the default arguments in addition to transition arguments.

### DIFF
--- a/src/State.php
+++ b/src/State.php
@@ -286,10 +286,17 @@ abstract class State implements Castable, JsonSerializable
     ): Transition {
         $transitionClass = $this->stateConfig->resolveTransitionClass($from, $to);
 
-        if ($transitionClass === null) {
-            $defaultTransition = config('model-states.default_transition', DefaultTransition::class);
+        $defaultTransition = config('model-states.default_transition', DefaultTransition::class);
 
+        if ($transitionClass === null) {
             $transition = new $defaultTransition(
+                $this->model,
+                $this->field,
+                $newState,
+                ...$transitionArgs
+            );
+        } elseif (is_a($transitionClass, $defaultTransition, true)) {
+            $transition = new $transitionClass(
                 $this->model,
                 $this->field,
                 $newState,

--- a/tests/Dummy/OtherModelStates/OtherModelState.php
+++ b/tests/Dummy/OtherModelStates/OtherModelState.php
@@ -4,6 +4,7 @@ namespace Spatie\ModelStates\Tests\Dummy\OtherModelStates;
 
 use Spatie\ModelStates\State;
 use Spatie\ModelStates\StateConfig;
+use Spatie\ModelStates\Tests\Dummy\Transitions\CustomDefaultTransition;
 use Spatie\ModelStates\Tests\Dummy\Transitions\CustomInvalidTransition;
 use Spatie\ModelStates\Tests\Dummy\Transitions\CustomTransition;
 
@@ -13,6 +14,7 @@ class OtherModelState extends State
     {
         return parent::config()
             ->allowTransition(StateX::class, StateY::class, CustomTransition::class)
-            ->allowTransition(StateX::class, StateZ::class, CustomInvalidTransition::class);
+            ->allowTransition(StateX::class, StateZ::class, CustomInvalidTransition::class)
+            ->allowTransition(StateY::class, StateZ::class, CustomDefaultTransition::class);
     }
 }

--- a/tests/TransitionTest.php
+++ b/tests/TransitionTest.php
@@ -17,6 +17,7 @@ use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateZ;
 use Spatie\ModelStates\Tests\Dummy\TestModel;
 use Spatie\ModelStates\Tests\Dummy\TestModelIgnoresSameState;
 use Spatie\ModelStates\Tests\Dummy\TestModelIgnoresSameStateByAttribute;
+use Spatie\ModelStates\Tests\Dummy\TestModelUpdatingEvent;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithCustomTransition;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithTransitionsFromArray;
 use Spatie\ModelStates\Tests\Dummy\Transitions\CustomInvalidTransition;
@@ -113,6 +114,20 @@ it('custom transition test', function () {
 
     expect($model->state)->toBeInstanceOf(StateY::class);
     expect($model->message)->toEqual($message);
+});
+
+it('custom transition inherited from default test', function () {
+    Event::fake();
+    $model = TestModelWithCustomTransition::create([
+        'state' => StateY::class,
+    ]);
+
+    $model->state->transitionTo(StateZ::class);
+
+    $model->refresh();
+
+    expect($model->state)->toBeInstanceOf(StateZ::class);
+    Event::assertNotDispatched(TestModelUpdatingEvent::class);
 });
 
 it('directly transition', function () {


### PR DESCRIPTION
### Foreword

Custom Transition can be passed the same parameters as the Default Transition if it's derived from it.

### Requirement

When creating and registering a custom transition, I'd like to inherit from the Default Transition to preserve any functionality I'm already implementing on all transition.

### Use case

Creating a custom transition that inherits from the Default Transition so default functionality is still applied.

E.g.

My Default Transition raises a domain Event for transition change.

I'd like to extend the Default Transition for a specific Transition and override the `canTransition` method to check something specific to that transition to determine whether it should proceed. I still want the domain Event to be raised, without needing to re-implement it in my Custom Transition class.