### PR TITLE
Add support for registering states from  multiple custom  directories.

### DIFF
--- a/docs/working-with-states/01-configuring-states.md
+++ b/docs/working-with-states/01-configuring-states.md
@@ -114,6 +114,36 @@ abstract class PaymentState extends State
 }
 ```
 
+## Registering states from custom directories
+
+If you want to register all state classes from one or more directories, you can use the `registerStatesFromDirectory` method. This is useful if you organize your state classes in multiple folders and want to avoid registering each one manually.
+
+```php
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\StateConfig;
+
+abstract class PaymentState extends State
+{
+    abstract public function color(): string;
+    
+    public static function config(): StateConfig
+    {
+        return parent::config()
+            ->default(Pending::class)
+            ->allowTransition(Pending::class, Paid::class)
+            ->allowTransition(Pending::class, Failed::class)
+            ->registerStatesFromDirectory(app_path('States/Payment'))
+            ->registerStatesFromDirectory(
+                __DIR__ . '/States',
+                __DIR__ . '/MoreStates',
+                // add as many directories as you need
+            );
+    }
+}
+```
+
+This will automatically discover and register all state classes in the given directory that extend your base state class.
+
 ### Registering custom StateChanged event
 By default, when a state is changed, the `StateChanged` event is fired. If you want to use a custom event, you can register it in the `config` method:
 

--- a/src/StateConfig.php
+++ b/src/StateConfig.php
@@ -178,6 +178,24 @@ class StateConfig
     }
 
     /**
+     * Register all state classes from one or more custom directories.
+     *
+     * @param string ...$directories
+     * @return $this
+     */
+    public function registerStatesFromDirectory(string ...$directories): StateConfig
+    {
+        $stateClasses = Discover::in(...$directories)
+            ->classes()
+            ->extending($this->baseStateClass)
+            ->get();
+
+        $this->registerState($stateClasses);
+
+        return $this;
+    }
+
+    /**
      * @param string|\Spatie\ModelStates\State $from
      * @param string|\Spatie\ModelStates\State $to
      *

--- a/tests/Dummy/RegisterStatesFromCustomDirectories/DefaultState.php
+++ b/tests/Dummy/RegisterStatesFromCustomDirectories/DefaultState.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories;
+
+class DefaultState extends RegisterStatesFromCustomDirectories
+{
+}

--- a/tests/Dummy/RegisterStatesFromCustomDirectories/Directory1/StateA.php
+++ b/tests/Dummy/RegisterStatesFromCustomDirectories/Directory1/StateA.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\Directory1;
+
+use Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\RegisterStatesFromCustomDirectories;
+
+class StateA extends RegisterStatesFromCustomDirectories
+{
+}

--- a/tests/Dummy/RegisterStatesFromCustomDirectories/Directory1/StateB.php
+++ b/tests/Dummy/RegisterStatesFromCustomDirectories/Directory1/StateB.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\Directory1;
+
+use Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\RegisterStatesFromCustomDirectories;
+
+class StateB extends RegisterStatesFromCustomDirectories
+{
+
+}

--- a/tests/Dummy/RegisterStatesFromCustomDirectories/Directory1/StateC.php
+++ b/tests/Dummy/RegisterStatesFromCustomDirectories/Directory1/StateC.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\Directory1;
+
+use Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\RegisterStatesFromCustomDirectories;
+
+class StateC extends RegisterStatesFromCustomDirectories
+{
+    public static string $name = 'C';
+}

--- a/tests/Dummy/RegisterStatesFromCustomDirectories/Directory2/StateF.php
+++ b/tests/Dummy/RegisterStatesFromCustomDirectories/Directory2/StateF.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\Directory2;
+
+use Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\RegisterStatesFromCustomDirectories;
+
+class StateF extends RegisterStatesFromCustomDirectories
+{
+}

--- a/tests/Dummy/RegisterStatesFromCustomDirectories/Directory2/StateG.php
+++ b/tests/Dummy/RegisterStatesFromCustomDirectories/Directory2/StateG.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\Directory2;
+
+use Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\RegisterStatesFromCustomDirectories;
+
+class StateG extends RegisterStatesFromCustomDirectories
+{
+    public static string $name = 'G';
+}

--- a/tests/Dummy/RegisterStatesFromCustomDirectories/Directory2/StateH.php
+++ b/tests/Dummy/RegisterStatesFromCustomDirectories/Directory2/StateH.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\Directory2;
+
+use Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\RegisterStatesFromCustomDirectories;
+
+class StateH extends RegisterStatesFromCustomDirectories
+{
+    public static int $name = 8;
+}

--- a/tests/Dummy/RegisterStatesFromCustomDirectories/RegisterStatesFromCustomDirectories.php
+++ b/tests/Dummy/RegisterStatesFromCustomDirectories/RegisterStatesFromCustomDirectories.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories;
+
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\StateConfig;
+
+abstract class RegisterStatesFromCustomDirectories extends State
+{
+    public static function config(): StateConfig
+    {
+        return parent::config()
+            ->registerStatesFromDirectory(__DIR__ . '/Directory1' , __DIR__ . '/Directory2')
+            ->default(DefaultState::class)
+            ->allowAllTransitions();
+    }
+}

--- a/tests/Dummy/TestModelWithCustomDirectories.php
+++ b/tests/Dummy/TestModelWithCustomDirectories.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\RegisterStatesFromCustomDirectories;
+
+class TestModelWithCustomDirectories extends TestModel
+{
+    protected $casts = [
+        'state' => RegisterStatesFromCustomDirectories::class,
+    ];
+}

--- a/tests/RegisterStatesFromCustomDirectoriesTest.php
+++ b/tests/RegisterStatesFromCustomDirectoriesTest.php
@@ -41,7 +41,7 @@ it('can transition between states registered from custom directories', function 
 it('get default states for', function () {
     $defaultState = TestModelWithCustomDirectories::getDefaultStateFor('state');
 
-    expect($defaultState)->toEqual(StateA::getMorphClass());
+    expect($defaultState)->toEqual(DefaultState::getMorphClass());
 });
 
 it('throws if a directory does not exist', function () {

--- a/tests/RegisterStatesFromCustomDirectoriesTest.php
+++ b/tests/RegisterStatesFromCustomDirectoriesTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Spatie\ModelStates\Tests\Dummy\TestModelWithCustomDirectories;
+use Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\Directory1\StateA;
+use Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\Directory1\StateB;
+use Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\Directory1\StateC;
+use Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\Directory2\StateF;
+use Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\Directory2\StateG;
+use Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\Directory2\StateH;
+use Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\DefaultState;
+use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
+
+it('registers all states from custom directories', function () {
+    $model = TestModelWithCustomDirectories::create([
+        'state' => StateA::class,
+    ]);
+
+    $registeredStates = $model->state::config()->registeredStates;
+
+    expect($registeredStates)->toContain(StateA::class);
+    expect($registeredStates)->toContain(StateB::class);
+    expect($registeredStates)->toContain(StateC::class);
+    expect($registeredStates)->toContain(StateF::class);
+    expect($registeredStates)->toContain(StateG::class);
+    expect($registeredStates)->toContain(StateH::class);
+    expect($registeredStates)->toContain(DefaultState::class);
+    expect(count($registeredStates))->toBeGreaterThanOrEqual(7);
+});
+
+it('can transition between states registered from custom directories', function () {
+    $model = TestModelWithCustomDirectories::create([
+        'state' => StateA::class,
+    ]);
+
+    $model->state->transitionTo(StateF::class);
+    $model->refresh();
+    expect($model->state)->toBeInstanceOf(StateF::class);
+});
+
+
+it('get default states for', function () {
+    $defaultState = TestModelWithCustomDirectories::getDefaultStateFor('state');
+
+    expect($defaultState)->toEqual(StateA::getMorphClass());
+});
+
+it('throws if a directory does not exist', function () {
+    $config = new \Spatie\ModelStates\StateConfig(
+        \Spatie\ModelStates\Tests\Dummy\RegisterStatesFromCustomDirectories\RegisterStatesFromCustomDirectories::class
+    );
+    $nonExistentDir = __DIR__ . '/Dummy/RegisterStatesFromCustomDirectories/DirectoryDoesNotExist';
+    expect(fn() => $config->registerStatesFromDirectory($nonExistentDir))->toThrow(DirectoryNotFoundException::class);
+});


### PR DESCRIPTION
### What’s Changed

- Added a `registerStatesFromDirectory(string ...$directories)` method to `StateConfig `to allow registering  all state classes from one or more directories.

- Updated the documentation to include usage instructions and an example for the new method.

### Why
This change makes it easier to organize and register state classes across multiple folders, reducing boilerplate and improving maintainability for larger codebases.

### _Note:_
Please let me know if additional or updated tests are needed