### PR TITLE
feat: support custom transition constructors extending DefaultTransit…

### DIFF
--- a/docs/working-with-transitions/06-custom-default-transition-class.md
+++ b/docs/working-with-transitions/06-custom-default-transition-class.md
@@ -24,13 +24,6 @@ class CustomDefaultTransitionWithAttributes extends DefaultTransition
 }
 ```
 
-Register your custom transition class in `config/model-states.php`:
-
-```php
-return [
-    'default_transition' => CustomDefaultTransitionWithAttributes::class
-];
-```
 
 Implement your state change listener to use the custom parameter:
 

--- a/src/State.php
+++ b/src/State.php
@@ -247,8 +247,10 @@ abstract class State implements Castable, JsonSerializable
         foreach ($otherStates as $otherState) {
             $otherState = $this->resolveStateObject($otherState);
 
-            if ($this->stateConfig->baseStateClass === $otherState->stateConfig->baseStateClass
-                && $this->getValue() === $otherState->getValue()) {
+            if (
+                $this->stateConfig->baseStateClass === $otherState->stateConfig->baseStateClass
+                && $this->getValue() === $otherState->getValue()
+            ) {
                 return true;
             }
         }
@@ -290,6 +292,13 @@ abstract class State implements Castable, JsonSerializable
             $defaultTransition = config('model-states.default_transition', DefaultTransition::class);
 
             $transition = new $defaultTransition(
+                $this->model,
+                $this->field,
+                $newState,
+                ...$transitionArgs
+            );
+        } elseif (is_subclass_of($transitionClass, DefaultTransition::class)) {
+            $transition = new $transitionClass(
                 $this->model,
                 $this->field,
                 $newState,

--- a/src/State.php
+++ b/src/State.php
@@ -287,7 +287,11 @@ abstract class State implements Castable, JsonSerializable
         ...$transitionArgs
     ): Transition {
         $transitionClass = $this->stateConfig->resolveTransitionClass($from, $to);
-
+        /**
+         * @deprecated This behavior should be removed in the next major release.
+         * Transitions will no longer need to be defined in the configuration file
+         * as long as they extend the DefaultTransition class.
+         */
         if ($transitionClass === null) {
             $defaultTransition = config('model-states.default_transition', DefaultTransition::class);
 

--- a/tests/Dummy/OtherModelStates/OtherModelState.php
+++ b/tests/Dummy/OtherModelStates/OtherModelState.php
@@ -4,6 +4,7 @@ namespace Spatie\ModelStates\Tests\Dummy\OtherModelStates;
 
 use Spatie\ModelStates\State;
 use Spatie\ModelStates\StateConfig;
+use Spatie\ModelStates\Tests\Dummy\Transitions\CustomDefaultTransitionWithAttributes;
 use Spatie\ModelStates\Tests\Dummy\Transitions\CustomInvalidTransition;
 use Spatie\ModelStates\Tests\Dummy\Transitions\CustomTransition;
 
@@ -13,6 +14,7 @@ class OtherModelState extends State
     {
         return parent::config()
             ->allowTransition(StateX::class, StateY::class, CustomTransition::class)
-            ->allowTransition(StateX::class, StateZ::class, CustomInvalidTransition::class);
+            ->allowTransition(StateX::class, StateZ::class, CustomInvalidTransition::class)
+            ->allowTransition(StateY::class, StateZ::class, CustomDefaultTransitionWithAttributes::class);
     }
 }

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -30,6 +30,7 @@ use Spatie\ModelStates\Tests\Dummy\TestModelUpdatingEvent;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithCustomTransition;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithDefault;
 use Spatie\ModelStates\Tests\Dummy\AllowAllTransitionsState;
+use Spatie\ModelStates\Tests\Dummy\OtherModelStates\StateZ;
 
 it('resolve state class', function () {
     expect(ModelState::resolveStateClass(StateA::class))->toEqual(StateA::class);
@@ -323,4 +324,15 @@ it('should throw exception when allowing all transitions when there are no regis
     $this->expectExceptionMessage('No states registered for ' . AllowAllTransitionsStateWithNoRegisteredStates\AllowAllTransitionsStateWithNoRegisteredStates::class);
 
     TestModelAllowAllTransitionsWithNoRegisteredStates::create();
+});
+
+it('uses custom transition extending DefaultTransition with correct arguments with out needing to explicitly set it as default in config', function () {
+
+    $model = new TestModelWithCustomTransition();
+    $model->state = StateY::class;
+    $model->save();
+    $model->state->setField('state');
+    $model->state->transitionTo(StateZ::class, true);
+    $model->refresh();
+    expect($model->state)->toBeInstanceOf(StateZ::class);
 });


### PR DESCRIPTION

## Support custom transitions extending `DefaultTransition` with full constructor arguments

### Summary

This PR enhances the `State` class to allow custom transition classes that extend `DefaultTransition` to receive the same constructor arguments as the default transition, even when not set as the global default in the config.

### Details

- Updates the `resolveTransitionClass` method to check if a registered transition extends `DefaultTransition`. If so, it passes `$model`, `$field`, `$newState`, and any additional arguments to the constructor.
- Adds a test to verify that a custom transition extending `DefaultTransition` (but not set as the default) is used correctly and receives all expected arguments.

### Why?

Previously, only the globally configured default transition received the full set of constructor arguments. Now, any transition extending `DefaultTransition` can leverage this.


