### PR TITLE
Add `transitionableStateInstances()`  method to get state objects for all transitionable states

### DIFF
--- a/docs/working-with-transitions/04-retrieving-transitionable-states.md
+++ b/docs/working-with-transitions/04-retrieving-transitionable-states.md
@@ -5,7 +5,6 @@ weight: 4
 
 An array of transitionable states can be retrieved using the `transitionableStates()` on the state field.
 
-
 ```php
 
 abstract class PaymentState extends State
@@ -31,6 +30,68 @@ This will return an array with all transitionable states for the current state, 
 [
     0 => "paid"
 ]
+```
+
+## Retrieving state instances
+
+If you need the actual state instances instead of just their string representations, you can use the `transitionableStateInstances()` method:
+
+```php
+$stateInstances = $payment->state->transitionableStateInstances();
+```
+
+This will return an array of instantiated state objects:
+
+```php
+[
+    0 => Paid {
+        // State instance with model reference
+    }
+]
+```
+
+### Simple example in Blade
+
+This method is particularly useful when you need to access state methods directly. For example, to display available transitions with their properties:
+
+```php
+@foreach($payment->state->transitionableStateInstances() as $stateInstance)
+    <div>
+        <span style="color: {{ $stateInstance->color() }}">{{ $stateInstance->label() }}</span>
+        <i class="{{ $stateInstance->icon() }}"></i>
+    </div>
+@endforeach
+```
+
+With this approach, you can directly call any method defined on your state classes, allowing you to encapsulate UI and business logic within your states:
+
+```php
+abstract class PaymentState extends State
+{
+    abstract public function color(): string;
+    abstract public function label(): string;
+    abstract public function icon(): string;
+
+    // ...other state methods
+}
+
+class Paid extends PaymentState
+{
+    public function color(): string
+    {
+        return '#4CAF50'; // green
+    }
+
+    public function label(): string
+    {
+        return 'Mark as Paid';
+    }
+
+    public function icon(): string
+    {
+        return 'check-circle';
+    }
+}
 ```
 
 ## Can transition to

--- a/src/State.php
+++ b/src/State.php
@@ -204,10 +204,31 @@ abstract class State implements Castable, JsonSerializable
         return $model;
     }
 
+    /**
+     * Get an array of state names that can be transitioned to from the current state.
+     *
+     * @param  mixed  ...$transitionArgs  Optional arguments to pass to the transition
+     * @return array  Array of state names as strings
+     */
     public function transitionableStates(...$transitionArgs): array
     {
         return collect($this->stateConfig->transitionableStates(static::getMorphClass()))->reject(function ($state) use ($transitionArgs) {
             return ! $this->canTransitionTo($state, ...$transitionArgs);
+        })->toArray();
+    }
+
+    /**
+     * Get an array of instantiated state objects that can be transitioned to from the current state.
+     *
+     * @param  mixed  ...$transitionArgs  Optional arguments to pass to the transition
+     * @return array  Array of state instances
+     */
+    public function transitionableStateInstances(...$transitionArgs): array
+    {
+        return collect($this->transitionableStates(...$transitionArgs))->map(function ($state) {
+            $stateClass = static::resolveStateClass($state);
+            $stateInstance = new $stateClass($this->getModel());
+            return $stateInstance;
         })->toArray();
     }
 

--- a/src/State.php
+++ b/src/State.php
@@ -226,9 +226,8 @@ abstract class State implements Castable, JsonSerializable
     public function transitionableStateInstances(...$transitionArgs): array
     {
         return collect($this->transitionableStates(...$transitionArgs))->map(function ($state) {
-            $stateClass = static::resolveStateClass($state);
-            $stateInstance = new $stateClass($this->getModel());
-            return $stateInstance;
+            $stateClass = $this::config()->baseStateClass::resolveStateClass($state);
+            return (new $stateClass($this->getModel()));
         })->toArray();
     }
 

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -72,6 +72,35 @@ it('transitionable states with custom transition', function () {
     expect($model->state->transitionableStates())->toBe([StateY::class]);
 });
 
+it('returns transitionable state instances', function () {
+    $model = TestModel::create([
+        'state' => StateA::class,
+    ]);
+
+    $stateInstances = $model->state->transitionableStateInstances();
+
+    expect($stateInstances)->toBeArray();
+    expect($stateInstances)->each->toBeObject();
+    expect($stateInstances)->toContainOnlyInstancesOf(ModelState::class);
+
+    // Test that the actual instances match what we expect based on allowed transitions
+    $stateClassNames = array_map(fn($instance) => get_class($instance), $stateInstances);
+    expect($stateClassNames)->toEqual([
+        StateB::class,
+        StateC::class,
+        StateD::class,
+        StateF::class,
+    ]);
+
+
+    $modelB = TestModelWithDefault::create([
+        'state' => StateC::class,
+    ]);
+
+    expect($modelB->state->transitionableStateInstances())->toEqual([]);
+});
+
+
 it('equals', function () {
     $modelA = TestModelWithDefault::create();
 


### PR DESCRIPTION
This PR adds a new transitionableStateInstances() method that returns an array of instantiated state objects instead of just their string representations. This makes it easier to access state methods directly in views or controllers without having to manually instantiate state objects.

Example use case:

```
@foreach($payment->state->transitionableStateInstances() as $stateInstance)
    <div>
        <span style="color: {{ $stateInstance->color() }}">{{ $stateInstance->label() }}</span>
    </div>
@endforeach
```
Added tests and updated documentation to reflect this new feature.