### PR TITLE
Add field property to StateChanged event

### DIFF
--- a/docs/working-with-transitions/05-transition-events.md
+++ b/docs/working-with-transitions/05-transition-events.md
@@ -3,4 +3,4 @@ title: Transition events
 weight: 5
 ---
 
-When a transition is successfully performed, an event will be dispatched called `\Spatie\ModelStates\Events\StateChanged`. This event hold references to the initial state (`initialState`), the new state (`finalState`), the transition class that performed the transition (`transition`) and the model that the transition was performed on (`model`). 
+When a transition is successfully performed, an event will be dispatched called `\Spatie\ModelStates\Events\StateChanged`. This event hold references to the initial state (`initialState`), the new state (`finalState`), the transition class that performed the transition (`transition`), the model that the transition was performed on (`model`)  and the field name that was transitioned `(field)`. 

--- a/src/Events/StateChanged.php
+++ b/src/Events/StateChanged.php
@@ -18,6 +18,8 @@ class StateChanged
 
     public $model;
 
+    public ?string $field;
+
     /**
      * @param  string|State|null  $initialState
      * @param  string|State|null  $finalState
@@ -28,11 +30,13 @@ class StateChanged
         ?State $initialState,
         ?State $finalState,
         Transition $transition,
-        $model
+        $model,
+        string $field
     ) {
         $this->initialState = $initialState;
         $this->finalState = $finalState;
         $this->transition = $transition;
         $this->model = $model;
+        $this->field = $field;
     }
 }

--- a/src/State.php
+++ b/src/State.php
@@ -199,6 +199,7 @@ abstract class State implements Castable, JsonSerializable
             $model->{$this->field},
             $transition,
             $this->model,
+            $this->field,
         ));
 
         return $model;

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -261,6 +261,18 @@ it('emits the standard state changed event', function () {
     Event::assertDispatched(StateChanged::class);
 });
 
+it('include the model state field in the changed event', function () {
+    Event::fake();
+
+    $model = TestModel::create();
+
+    $model->state->transitionTo(StateB::class);
+
+    Event::assertDispatched(StateChanged::class, function (StateChanged $stateChanged) {
+        return $stateChanged->field == 'state';
+    });
+});
+
 it('should throw exception when custom state changed event does not extend StateChanged', function () {
     Event::fake();
 


### PR DESCRIPTION
## Description
This PR enhances the `StateChanged` event by adding a `field` property that tracks which model state field triggered the event.

## Changes
- Added a `field` property to the `StateChanged` event class
- Modified the `State` class to pass the field name when dispatching the event
- Added a test to verify that the field property is correctly populated in the event
