### PR TITLE
Fix PHP 8.5 trait binding order bug when state is cast via casts() method

### DIFF
--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -105,7 +105,7 @@ trait HasStates
      */
     private function getStateConfigs(): array
     {
-        $casts = $this->getCasts();
+        $casts = array_merge($this->casts, $this->casts());
 
         $states = [];
 

--- a/tests/Dummy/TestModelWithCastsMethod.php
+++ b/tests/Dummy/TestModelWithCastsMethod.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\ModelStates\HasStates;
+use Spatie\ModelStates\Tests\Dummy\ModelStates\ModelState;
+
+/**
+ * @property \Spatie\ModelStates\Tests\Dummy\ModelStates\ModelState state
+ */
+class TestModelWithCastsMethod extends Model
+{
+    use HasStates;
+
+    protected $guarded = [];
+
+    protected function casts(): array
+    {
+        return [
+            'state' => ModelState::class,
+        ];
+    }
+
+    public function getTable()
+    {
+        return 'test_models';
+    }
+}

--- a/tests/StateCastingTest.php
+++ b/tests/StateCastingTest.php
@@ -8,6 +8,7 @@ use Spatie\ModelStates\Tests\Dummy\ModelStates\StateC;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateF;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateG;
 use Spatie\ModelStates\Tests\Dummy\TestModel;
+use Spatie\ModelStates\Tests\Dummy\TestModelWithCastsMethod;
 
 it('state without alias is serialized on create', function () {
     $model = TestModel::create([
@@ -149,4 +150,20 @@ it('respects jsonSerialize in state classes', function() {
     ]);
 
     expect($model->toJson())->toBe('{"state":{"name":"StateB"}}');
+});
+
+it('resolves state defaults on a fresh unsaved model when cast is declared via casts() method', function () {
+    // Regression test for PHP 8.5 trait binding order change: on PHP 8.5,
+    // initializeHasStates() runs before initializeHasAttributes(), so $this->casts
+    // may not yet contain values from the casts() method when setStateDefaults() fires.
+    // getStateConfigs() must read both the $casts property and the casts() method directly.
+    $model = new TestModelWithCastsMethod();
+
+    expect($model->state)->toBeInstanceOf(StateA::class);
+});
+
+it('resolves state on a fresh unsaved model constructed with attributes when cast is declared via casts() method', function () {
+    $model = new TestModelWithCastsMethod(['state' => StateB::class]);
+
+    expect($model->state)->toBeInstanceOf(StateB::class);
 });


### PR DESCRIPTION
## What's Changed

On PHP 8.5, traits are bound before the parent class, which changes the order `ReflectionClass::getMethods()` returns methods. This means `initializeHasStates()` now runs before `initializeHasAttributes()`, so when a model declares its casts via the `casts()` method (rather than the `$casts` property), `$this->casts` hasn't been populated yet when `setStateDefaults()` fires.

This only affects unsaved model instances (`new Model()`, `Model::factory()->make()`). Models loaded from the database are unaffected.

## The Fix

In `getStateConfigs()`, replace `$this->getCasts()` with `array_merge($this->casts, $this->casts())`. The property is always available, and calling `casts()` directly has no initialization dependency. Together they give the complete picture regardless of trait binding order.