### PR TITLE
Fix PHP 8.5 regression writing raw state FQN for aliased defaults

### DIFF
--- a/src/HasStates.php
+++ b/src/HasStates.php
@@ -23,6 +23,12 @@ trait HasStates
 
     public function initializeHasStates(): void
     {
+        // On PHP 8.5 this trait can initialize before HasAttributes, so the
+        // casts() method hasn't been merged into $this->casts yet. Merge it
+        // ourselves so setAttribute() can locate the StateCaster below and
+        // store the morph alias instead of the raw state FQN.
+        $this->casts = array_merge($this->casts, $this->casts());
+
         $this->setStateDefaults();
     }
 

--- a/tests/Dummy/AliasedModelStates/AliasedModelState.php
+++ b/tests/Dummy/AliasedModelStates/AliasedModelState.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AliasedModelStates;
+
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\StateConfig;
+
+abstract class AliasedModelState extends State
+{
+    public static function config(): StateConfig
+    {
+        return parent::config()
+            ->default(Pending::class);
+    }
+}

--- a/tests/Dummy/AliasedModelStates/Approved.php
+++ b/tests/Dummy/AliasedModelStates/Approved.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AliasedModelStates;
+
+class Approved extends AliasedModelState
+{
+    public static string $name = 'approved';
+}

--- a/tests/Dummy/AliasedModelStates/Pending.php
+++ b/tests/Dummy/AliasedModelStates/Pending.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy\AliasedModelStates;
+
+class Pending extends AliasedModelState
+{
+    public static string $name = 'pending';
+}

--- a/tests/Dummy/TestModelWithAliasedDefaultCastsMethod.php
+++ b/tests/Dummy/TestModelWithAliasedDefaultCastsMethod.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spatie\ModelStates\Tests\Dummy;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\ModelStates\HasStates;
+use Spatie\ModelStates\Tests\Dummy\AliasedModelStates\AliasedModelState;
+
+/**
+ * @property \Spatie\ModelStates\Tests\Dummy\AliasedModelStates\AliasedModelState state
+ */
+class TestModelWithAliasedDefaultCastsMethod extends Model
+{
+    use HasStates;
+
+    protected $guarded = [];
+
+    protected function casts(): array
+    {
+        return [
+            'state' => AliasedModelState::class,
+        ];
+    }
+
+    public function getTable(): string
+    {
+        return 'test_models';
+    }
+}

--- a/tests/StateCastingTest.php
+++ b/tests/StateCastingTest.php
@@ -7,7 +7,9 @@ use Spatie\ModelStates\Tests\Dummy\ModelStates\StateB;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\StateC;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateF;
 use Spatie\ModelStates\Tests\Dummy\ModelStates\AnotherDirectory\StateG;
+use Spatie\ModelStates\Tests\Dummy\AliasedModelStates\Pending;
 use Spatie\ModelStates\Tests\Dummy\TestModel;
+use Spatie\ModelStates\Tests\Dummy\TestModelWithAliasedDefaultCastsMethod;
 use Spatie\ModelStates\Tests\Dummy\TestModelWithCastsMethod;
 
 it('state without alias is serialized on create', function () {
@@ -166,4 +168,17 @@ it('resolves state on a fresh unsaved model constructed with attributes when cas
     $model = new TestModelWithCastsMethod(['state' => StateB::class]);
 
     expect($model->state)->toBeInstanceOf(StateB::class);
+});
+
+it('resolves an aliased default state when cast is declared via casts() method', function () {
+    // Regression test for spatie/laravel-model-states#307: under PHP 8.5 trait
+    // init order, initializeHasStates() fires before initializeHasAttributes(),
+    // so $this->casts doesn't yet contain casts() entries when setStateDefaults()
+    // writes the default. setAttribute() skipped the StateCaster and stored the
+    // raw FQN instead of the morph alias, which later blew up in StateCaster::get
+    // with "Undefined array key" because the mapping is keyed by alias.
+    $model = new TestModelWithAliasedDefaultCastsMethod();
+
+    expect($model->state)->toBeInstanceOf(Pending::class);
+    expect($model->getAttributes()['state'] ?? null)->toBe(Pending::getMorphClass());
 });


### PR DESCRIPTION
## Summary

Fixes the regression introduced in 2.14.0 that's reported in discussion [#307](https://github.com/spatie/laravel-model-states/discussions/307).

## Root cause

Under PHP 8.5 trait init order, `initializeHasStates()` runs before `initializeHasAttributes()`. #306 made `getStateConfigs()` read both `$this->casts` and `$this->casts()` so defaults get detected, but setting them is still broken:

1. `setStateDefaults()` writes `$this->{$field} = $stateConfig->defaultStateClass` (the FQN).
2. Laravel's `setAttribute()` calls `isClassCastable($key)`, which consults `getCasts()`. `getCasts()` returns only `$this->casts`, and the `casts()` method hasn't been merged into that property yet.
3. `isClassCastable` returns `false`, the `StateCaster` is skipped, and the raw FQN is stored in `$this->attributes['state']`.
4. Once `initializeHasAttributes()` runs, the cast is registered. On read, `StateCaster::get()` does `$mapping[$value]`. The mapping is keyed by morph alias, so the FQN lookup throws `Undefined array key` inside `Collection::offsetGet`.

The bug only surfaces when all three are true: PHP 8.5, the state cast is declared via the `casts()` method, and the default state defines a `\$name` alias.

## Fix

Merge `casts()` into `\$this->casts` inside `initializeHasStates()` before calling `setStateDefaults()`. This mirrors what `initializeHasAttributes()` does later (and is idempotent with it), guaranteeing the cast is registered before any default is written.

## Test plan

- [x] New regression test `it resolves an aliased default state when cast is declared via casts() method` fails on current main with the exact error from the discussion, and passes with the fix.
- [x] Full Pest suite (73 tests, 168 assertions) green locally on PHP 8.5.

Refs #307.